### PR TITLE
(TK-128) fix tokenization of unquoted strings

### DIFF
--- a/lib/hocon/impl/parser.rb
+++ b/lib/hocon/impl/parser.rb
@@ -564,9 +564,7 @@ class Hocon::Impl::Parser
       end
 
       t = next_token_ignoring_newline
-      result = nil
-      if (t.token == Tokens::OPEN_CURLY) or
-          (t.token == Tokens::OPEN_SQUARE)
+      if (t.token == Tokens::OPEN_CURLY) or (t.token == Tokens::OPEN_SQUARE)
         result = parse_value(t)
       else
         if @syntax == ConfigSyntax::JSON

--- a/lib/hocon/impl/tokenizer.rb
+++ b/lib/hocon/impl/tokenizer.rb
@@ -266,15 +266,15 @@ class Hocon::Impl::Tokenizer
       begin
         if contained_decimal_or_e
           # force floating point representation
-          Tokens.new_float(@line_origin, s.to_f, s)
+          Tokens.new_float(@line_origin, Float(s), s)
         else
-          Tokens.new_long(@line_origin, s.to_i, s)
+          Tokens.new_long(@line_origin, Integer(s), s)
         end
       rescue ArgumentError => e
         if e.message =~ /^invalid value for (Float|Integer)\(\)/
           # not a number after all, see if it's an unquoted string.
-          s.each do |u|
-            if NOT_IN_UNQUOTED_TEXT.index
+          s.each_char do |u|
+            if NOT_IN_UNQUOTED_TEXT.index(u)
               raise self.class.problem(@line_origin, u, "Reserved character '#{u}'" +
                 "is not allowed outside quotes", true, nil)
             end

--- a/spec/fixtures/parse_render/example2/input.conf
+++ b/spec/fixtures/parse_render/example2/input.conf
@@ -7,3 +7,7 @@ jruby-puppet: {
     master-conf-dir: /etc/puppet
     master-var-dir: /var/lib/puppet
 }
+
+webserver: {
+  host: 1.2.3.4
+}

--- a/spec/fixtures/parse_render/example2/output.conf
+++ b/spec/fixtures/parse_render/example2/output.conf
@@ -13,3 +13,7 @@ jruby-puppet {
     master-conf-dir="/etc/puppet"
     master-var-dir="/var/lib/puppet"
 }
+
+webserver {
+  host="1.2.3.4"
+}

--- a/spec/fixtures/parse_render/example2/output_nocomments.conf
+++ b/spec/fixtures/parse_render/example2/output_nocomments.conf
@@ -11,3 +11,7 @@ jruby-puppet {
     master-conf-dir="/etc/puppet"
     master-var-dir="/var/lib/puppet"
 }
+
+webserver {
+  host="1.2.3.4"
+}

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,11 +16,12 @@ EXAMPLE1 = { :hash =>
 
 EXAMPLE2 = { :hash =>
     {"jruby-puppet"=> {
-      "jruby-pools" => [{"environment" => "production"}],
-      "load-path" => ["/usr/lib/ruby/site_ruby/1.8", "/usr/lib/ruby/site_ruby/1.8"],
-      "master-conf-dir" => "/etc/puppet",
-      "master-var-dir" => "/var/lib/puppet",
-    }},
+        "jruby-pools" => [{"environment" => "production"}],
+        "load-path" => ["/usr/lib/ruby/site_ruby/1.8", "/usr/lib/ruby/site_ruby/1.8"],
+        "master-conf-dir" => "/etc/puppet",
+        "master-var-dir" => "/var/lib/puppet",
+    },
+    "webserver" => {"host" => "1.2.3.4"}},
     :name => "example2",
   }
 

--- a/spec/unit/typesafe/config/hocon_spec.rb
+++ b/spec/unit/typesafe/config/hocon_spec.rb
@@ -24,6 +24,7 @@ describe Hocon do
     let(:output_nocomments_file) { "#{FIXTURE_DIR}/parse_render/#{example[:name]}/output_nocomments.conf" }
     let(:output_nocomments) { File.read("#{output_nocomments_file}") }
     let(:expected) { example[:hash] }
+    # TODO 'reparsed' appears to be unused
     let(:reparsed) { Hocon::ConfigFactory.parse_file("#{FIXTURE_DIR}/parse_render/#{example[:name]}/output.conf") }
 
     context "parsing a HOCON file" do


### PR DESCRIPTION
This commit fixes the tokenization of unquoted strings which might be
numbers.  In particular, this affects IP addresses.

The tokenizer aggressively attempts to parse such strings as
either a Float or Integer and relies on an error being raised to
indicate when the string is not actually a valid number.  However,
`to_i` and `to_f` never raise execptions, so the constructors must be
used instead.