### PR TITLE
Add lossless comment tokens

### DIFF
--- a/lib/hocon/impl/token.rb
+++ b/lib/hocon/impl/token.rb
@@ -2,14 +2,15 @@ require 'hocon/impl'
 require 'hocon/impl/token_type'
 
 class Hocon::Impl::Token
-  attr_reader :token_type
-  def self.new_without_origin(token_type, debug_string)
-    Hocon::Impl::Token.new(token_type, nil, debug_string)
+  attr_reader :token_type, :token_text
+  def self.new_without_origin(token_type, debug_string, token_text)
+    Hocon::Impl::Token.new(token_type, nil, token_text, debug_string)
   end
 
-  def initialize(token_type, origin, debug_string = nil)
+  def initialize(token_type, origin, token_text = nil, debug_string = nil)
     @token_type = token_type
     @origin = origin
+    @token_text = token_text
     @debug_string = debug_string
   end
 

--- a/lib/hocon/impl/token_type.rb
+++ b/lib/hocon/impl/token_type.rb
@@ -17,6 +17,7 @@ class Hocon::Impl::TokenType
   PROBLEM = 13
   COMMENT = 14
   PLUS_EQUALS = 15
+  IGNORED_WHITESPACE = 16
 
   def self.name(token_type)
     case token_type
@@ -36,6 +37,7 @@ class Hocon::Impl::TokenType
       when PROBLEM then "PROBLEM"
       when COMMENT then "COMMENT"
       when PLUS_EQUALS then "PLUS_EQUALS"
+      when IGNORED_WHITESPACE then "IGNORED_WHITESPACE"
       else raise ConfigBugError, "Unrecognized token type #{token_type}"
     end
   end

--- a/spec/test_utils.rb
+++ b/spec/test_utils.rb
@@ -29,6 +29,10 @@ module TestUtils
     token_iterator.to_list
   end
 
+  def TestUtils.tokenize_as_string(input_string)
+    Hocon::Impl::Tokenizer.render(tokenize(input_string))
+  end
+
   def TestUtils.fake_origin
     Hocon::Impl::SimpleConfigOrigin.new_simple("fake origin")
   end
@@ -53,12 +57,20 @@ module TestUtils
     Tokens.new_unquoted_text(fake_origin, value)
   end
 
-  def TestUtils.token_comment(value)
-    Tokens.new_comment(fake_origin, value)
+  def TestUtils.token_comment_double_slash(value)
+    Tokens.new_comment_double_slash(fake_origin, value)
+  end
+
+  def TestUtils.token_comment_hash(value)
+    Tokens.new_comment_hash(fake_origin, value)
+  end
+
+  def TestUtils.token_whitespace(value)
+    Tokens.new_ignored_whitespace(fake_origin, value)
   end
 
   def TestUtils.token_string(value)
-    Tokens.new_string(fake_origin, value)
+    Tokens.new_string(fake_origin, value, value)
   end
 
   def TestUtils.token_float(value)
@@ -70,7 +82,7 @@ module TestUtils
   end
 
   def TestUtils.token_maybe_optional_substitution(optional, token_list)
-    Tokens.new_substitution(fake_origin(), optional, token_list)
+    Tokens.new_substitution(fake_origin, optional, token_list)
   end
 
   def TestUtils.token_substitution(*token_list)

--- a/spec/unit/typesafe/config/tokenizer_spec.rb
+++ b/spec/unit/typesafe/config/tokenizer_spec.rb
@@ -57,7 +57,7 @@ describe Hocon::Impl::Tokenizer do
       include_examples "token_matching"
     end
 
-    context "tokenize unquoted text should trim spaces, keep internal spaces" do
+    context "tokenize unquoted text with internal spaces should keep spaces" do
       let(:test_string) { "    foo bar baz   \n" }
       let(:expected_tokens) { [TestUtils.token_whitespace("    "),
                                TestUtils.token_unquoted("foo"),


### PR DESCRIPTION
This is a direct port of the following PR: https://github.com/typesafehub/config/pull/271
As described in the above PR, this allows Tokens to keep track of the original text from which they were parsed. It also adds a new IgnoredWhitespace token to represent whitespace ignored by the parser that was previously thrown out when tokenizing input. Finally, a render() method has been added to the TokenIterator class, which reproduces the original input text.