### PR TITLE
(maint) rename methods to match upstream

### DIFF
--- a/lib/hocon/config_parse_options.rb
+++ b/lib/hocon/config_parse_options.rb
@@ -18,7 +18,7 @@ class Hocon::ConfigParseOptions
     @allow_missing
   end
 
-  def with_syntax(syntax)
+  def set_syntax(syntax)
     if @syntax == syntax
       self
     else
@@ -29,7 +29,7 @@ class Hocon::ConfigParseOptions
     end
   end
 
-  def with_origin_description(origin_description)
+  def set_origin_description(origin_description)
     if @origin_description == origin_description
       self
     else
@@ -40,7 +40,7 @@ class Hocon::ConfigParseOptions
     end
   end
 
-  def with_includer(includer)
+  def set_includer(includer)
     if @includer == includer
       self
     else
@@ -55,9 +55,9 @@ class Hocon::ConfigParseOptions
     if @includer == includer
       self
     elsif @includer
-      with_includer(@includer.with_fallback(includer))
+      set_includer(@includer.with_fallback(includer))
     else
-      with_includer(includer)
+      set_includer(includer)
     end
   end
 

--- a/lib/hocon/impl/parseable.rb
+++ b/lib/hocon/impl/parseable.rb
@@ -151,9 +151,9 @@ class Hocon::Impl::Parseable
       syntax = Hocon::ConfigSyntax::CONF
     end
 
-    modified = base_options.with_syntax(syntax)
+    modified = base_options.set_syntax(syntax)
     modified = modified.append_includer(Hocon::Impl::ConfigImpl.default_includer)
-    modified = modified.with_includer(Hocon::Impl::SimpleIncluder.make_full(modified.includer))
+    modified = modified.set_includer(Hocon::Impl::SimpleIncluder.make_full(modified.includer))
 
     modified
   end

--- a/lib/hocon/impl/parser.rb
+++ b/lib/hocon/impl/parser.rb
@@ -251,7 +251,7 @@ class Hocon::Impl::Parser
     end
 
     def line_origin
-      @base_origin.set_line_number(@line_number)
+      @base_origin.with_line_number(@line_number)
     end
 
     def parse_value(t)
@@ -307,11 +307,11 @@ class Hocon::Impl::Parser
       keys = keys.reverse
       # this is just a ruby means for doing first/rest
       deepest, *rest = *keys
-      o = SimpleConfigObject.new(value.origin.set_comments(nil),
+      o = SimpleConfigObject.new(value.origin.with_comments(nil),
                                  {deepest => value})
       while !rest.empty?
         deepest, *rest = *rest
-        o = SimpleConfigObject.new(value.origin.set_comments(nil),
+        o = SimpleConfigObject.new(value.origin.with_comments(nil),
                                    {deepest => o})
       end
 

--- a/lib/hocon/impl/simple_config_origin.rb
+++ b/lib/hocon/impl/simple_config_origin.rb
@@ -133,7 +133,7 @@ class Hocon::Impl::SimpleConfigOrigin
   attr_reader :description, :line_number, :end_line_number, :origin_type,
               :url_or_nil, :comments_or_nil
 
-  def set_line_number(line_number)
+  def with_line_number(line_number)
     if (line_number == @line_number) and
         (line_number == @end_line_number)
       self
@@ -144,7 +144,7 @@ class Hocon::Impl::SimpleConfigOrigin
     end
   end
 
-  def set_comments(comments)
+  def with_comments(comments)
     if Hocon::Impl::ConfigImplUtil.equals_handling_nil?(comments, @comments_or_nil)
       self
     else
@@ -158,12 +158,12 @@ class Hocon::Impl::SimpleConfigOrigin
     if Hocon::Impl::ConfigImplUtil.equals_handling_nil?(comments, @comments_or_nil)
       self
     elsif @comments_or_nil.nil?
-      set_comments(comments)
+      with_comments(comments)
     else
       merged = []
       merged.concat(comments)
       merged.concat(@comments_or_nil)
-      set_comments(merged)
+      with_comments(merged)
     end
   end
 

--- a/lib/hocon/impl/tokenizer.rb
+++ b/lib/hocon/impl/tokenizer.rb
@@ -39,7 +39,7 @@ class Hocon::Impl::Tokenizer
       end
 
       def line_origin(base_origin, line_number)
-        base_origin.set_line_number(line_number)
+        base_origin.with_line_number(line_number)
       end
 
       private
@@ -114,7 +114,7 @@ class Hocon::Impl::Tokenizer
       @allow_comments = allow_comments
       @buffer = []
       @line_number = 1
-      @line_origin = @origin.set_line_number(@line_number)
+      @line_origin = @origin.with_line_number(@line_number)
       @tokens = []
       @tokens << Tokens::START
       @whitespace_saver = WhitespaceSaver.new
@@ -365,7 +365,7 @@ class Hocon::Impl::Tokenizer
           elsif c == "\n"
             # keep the line number accurate
             @line_number += 1
-            @line_origin = @origin.set_line_number(@line_number)
+            @line_origin = @origin.with_line_number(@line_number)
           end
         end
 
@@ -483,7 +483,7 @@ class Hocon::Impl::Tokenizer
         # newline tokens have the just-ended line number
         line = Tokens.new_line(@line_origin)
         @line_number += 1
-        @line_origin = @origin.set_line_number(@line_number)
+        @line_origin = @origin.with_line_number(@line_number)
         line
       else
         t = nil

--- a/spec/test_utils.rb
+++ b/spec/test_utils.rb
@@ -38,7 +38,7 @@ module TestUtils
   end
 
   def TestUtils.token_line(line_number)
-    Tokens.new_line(fake_origin.set_line_number(line_number))
+    Tokens.new_line(fake_origin.with_line_number(line_number))
   end
 
   def TestUtils.token_true
@@ -99,8 +99,8 @@ module TestUtils
 
   def TestUtils.parse_config(s)
     options = Hocon::ConfigParseOptions.defaults
-                  .with_origin_description("test string")
-                  .with_syntax(Hocon::ConfigSyntax::CONF)
+                  .set_origin_description("test string")
+                  .set_syntax(Hocon::ConfigSyntax::CONF)
     Hocon::ConfigFactory.parse_string(s, options)
   end
 


### PR DESCRIPTION
Rename methods whose names start with "set_" or "with_" to match
the names of these methods in the upstream Java project.

@jpinsonault and I discussed this the other day.