### PR TITLE
(TK-159) Partial set of ConfigValue tests implemented

### DIFF
--- a/lib/hocon/impl/config_delayed_merge.rb
+++ b/lib/hocon/impl/config_delayed_merge.rb
@@ -1,0 +1,59 @@
+require 'hocon/impl'
+require 'hocon/impl/replaceable_merge_stack'
+require 'hocon/impl/config_delayed_merge_object'
+
+class Hocon::Impl::ConfigDelayedMerge < Hocon::Impl::AbstractConfigValue
+  include Hocon::Impl::Unmergeable
+  include Hocon::Impl::ReplaceableMergeStack
+
+  def initialize(origin, stack)
+    super(origin)
+    @stack = stack
+
+    if stack.empty?
+      raise Hocon::ConfigError::ConfigBugOrBrokenError.new("creating empty delayed merge value", nil)
+    end
+
+    stack.each do |v|
+      if v.is_a?(Hocon::Impl::ConfigDelayedMerge) || v.is_a?(Hocon::Impl::ConfigDelayedMergeObject)
+        error_message = "placed nested DelayedMerge in a ConfigDelayedMerge, should have consolidated stack"
+        raise Hocon::ConfigError::ConfigBugOrBrokenError.new(error_message, nil)
+      end
+    end
+  end
+
+  attr_reader :stack
+
+
+  def value_type
+    error_message = "called value_type() on value with unresolved substitutions, need to Config#resolve() first, see API docs"
+    raise Hocon::ConfigError::ConfigNotResolvedError.new(error_message, nil)
+  end
+
+  def unwrapped
+    error_message = "called unwrapped() on value with unresolved substitutions, need to Config#resolve() first, see API docs"
+    raise Hocon::ConfigError::ConfigNotResolvedError.new(error_message, nil)
+  end
+
+  def resolve_status
+    Hocon::Impl::ResolveStatus::UNRESOLVED
+  end
+
+  def can_equal(other)
+    other.is_a? Hocon::Impl::ConfigDelayedMerge
+  end
+
+  def ==(other)
+    # note that "origin" is deliberately NOT part of equality
+    if other.is_a? Hocon::Impl::ConfigDelayedMerge
+      can_equal(other) && (@stack == other.stack || @stack.equal?(other.stack))
+    else
+      false
+    end
+  end
+
+  def hash
+    # note that "origin" is deliberately NOT part of equality
+    @stack.hash
+  end
+end

--- a/lib/hocon/impl/config_delayed_merge_object.rb
+++ b/lib/hocon/impl/config_delayed_merge_object.rb
@@ -1,0 +1,174 @@
+require 'hocon/impl'
+require 'hocon/impl/unmergeable'
+
+class Hocon::Impl::ConfigDelayedMergeObject < Hocon::Impl::AbstractConfigObject
+  include Hocon::Impl::Unmergeable
+  include Hocon::Impl::ReplaceableMergeStack
+
+  def initialize(origin, stack)
+    super(origin)
+
+    @stack = stack
+
+    if stack.empty?
+      raise Hocon::ConfigError::ConfigBugOrBrokenError.new("creating empty delayed merge value", nil)
+    end
+
+    if !@stack[0].is_a? Hocon::Impl::AbstractConfigObject
+      error_message = "created a delayed merge object not guaranteed to be an object"
+      raise Hocon::ConfigError::ConfigBugOrBrokenError.new(error_message, nil)
+    end
+
+    stack.each do |v|
+      if v.is_a?(Hocon::Impl::ConfigDelayedMergeObject) || v.is_a?(Hocon::Impl::ConfigDelayedMergeObject)
+        error_message = "placed nested DelayedMerge in a ConfigDelayedMerge, should have consolidated stack"
+        raise Hocon::ConfigError::ConfigBugOrBrokenError.new(error_message, nil)
+      end
+    end
+  end
+
+  attr_reader :stack
+
+  def self.not_resolved
+    error_message = "need to Config#resolve() before using this object, see the API docs for Config#resolve()"
+    Hocon::ConfigError::ConfigNotResolvedError.new(error_message, nil)
+  end
+
+  def unwrapped
+    error_message = "called unwrapped() on value with unresolved substitutions, need to Config#resolve() first, see API docs"
+    raise Hocon::ConfigError::ConfigNotResolvedError.new(error_message, nil)
+  end
+
+  def [](key)
+    raise self.class.not_resolved
+  end
+
+  def has_key?(key)
+    raise self.class.not_resolved
+  end
+
+  def has_value?(value)
+    raise self.class.not_resolved
+  end
+
+  def each
+    raise self.class.not_resolved
+  end
+
+  def empty?
+    raise self.class.not_resolved
+  end
+
+  def keys
+    raise self.class.not_resolved
+  end
+
+  def values
+    raise self.class.not_resolved
+  end
+
+  def size
+    raise self.class.not_resolved
+  end
+
+  def self.unmergeable?(object)
+    # Ruby note: This is the best way I could find to simulate
+    # else if (layer instanceof Unmergeable) in java since we're including
+    # the Unmergeable module instead of extending an Unmergeable class
+    object.class.included_modules.include?(Hocon::Impl::Unmergeable)
+  end
+
+  def attempt_peek_with_partial_resolve(key)
+    # a partial resolve of a ConfigDelayedMergeObject always results in a
+    # SimpleConfigObject because all the substitutions in the stack get
+    # resolved in order to look up the partial.
+    # So we know here that we have not been resolved at all even
+    # partially.
+    # Given that, all this code is probably gratuitous, since the app code
+    # is likely broken. But in general we only throw NotResolved if you try
+    # to touch the exact key that isn't resolved, so this is in that
+    # spirit.
+
+    # we'll be able to return a key if we have a value that ignores
+    # fallbacks, prior to any unmergeable values.
+    @stack.each do |layer|
+      if layer.is_a?(Hocon::Impl::AbstractConfigObject)
+        v = layer.attempt_peek_with_partial_resolve(key)
+
+        if !v.nil?
+          if v.ignores_fallbacks
+            # we know we won't need to merge anything in to this
+            # value
+            return v
+          else
+            # we can't return this value because we know there are
+            # unmergeable values later in the stack that may
+            # contain values that need to be merged with this
+            # value. we'll throw the exception when we get to those
+            # unmergeable values, so continue here.
+            next
+          end
+        elsif self.class.unmergeable?(layer)
+          error_message = "should not be reached: unmergeable object returned null value"
+          raise Hocon::ConfigError::ConfigBugOrBrokenError.new(error_message, nil)
+        else
+          # a non-unmergeable AbstractConfigObject that returned null
+          # for the key in question is not relevant, we can keep
+          # looking for a value.
+          next
+        end
+      elsif self.class.unmergeable?(layer)
+        error_message = "Key '#{key}' is not available at '#{origin.description}'" +
+            "because value at '#{layer.origin.description}' has not been resolved" +
+            " and may turn out to contain or hide '#{key}'. Be sure to Config#resolve()" +
+            " before using a config object"
+        raise Hocon::ConfigError::ConfigNotResolvedError.new(error_message, nil)
+      elsif layer.resolved_status == ResolveStatus::UNRESOLVED
+        # if the layer is not an object, and not a substitution or
+        # merge,
+        # then it's something that's unresolved because it _contains_
+        # an unresolved object... i.e. it's an array
+        if !layer.is_a?(Hocon::Impl::ConfigList)
+          error_message = "Expecting a list here, not #{layer}"
+          raise Hocon::ConfigError::ConfigBugOrBrokenError.new(error_message, nil)
+        end
+        return nil
+      else
+        # non-object, but resolved, like an integer or something.
+        # has no children so the one we're after won't be in it.
+        # we would only have this in the stack in case something
+        # else "looks back" to it due to a cycle.
+        # anyway at this point we know we can't find the key anymore.
+        if !layer.ignores_fallbacks
+          error_message = "resolved non-object should ignore fallbacks"
+          raise Hocon::ConfigError::ConfigBugOrBrokenError.new(error_message, nil)
+        end
+        return nil
+      end
+    end
+
+    # If we get here, then we never found anything unresolved which means
+    # the ConfigDelayedMergeObject should not have existed. some
+    # invariant was violated.
+    error_message = "Delayed merge stack does not contain any unmergeable values"
+    raise Hocon::ConfigError::ConfigBugOrBrokenError.new(error_message, nil)
+  end
+
+  def can_equal(other)
+    other.is_a? Hocon::Impl::ConfigDelayedMergeObject
+  end
+
+  def ==(other)
+    # note that "origin" is deliberately NOT part of equality
+    if other.is_a? Hocon::Impl::ConfigDelayedMergeObject
+      can_equal(other) && (@stack == other.stack || @stack.equal?(other.stack))
+    else
+      false
+    end
+  end
+
+  def hash
+    # note that "origin" is deliberately NOT part of equality
+    @stack.hash
+  end
+end

--- a/lib/hocon/impl/config_delayed_merge_object.rb
+++ b/lib/hocon/impl/config_delayed_merge_object.rb
@@ -35,8 +35,7 @@ class Hocon::Impl::ConfigDelayedMergeObject < Hocon::Impl::AbstractConfigObject
   end
 
   def unwrapped
-    error_message = "called unwrapped() on value with unresolved substitutions, need to Config#resolve() first, see API docs"
-    raise Hocon::ConfigError::ConfigNotResolvedError.new(error_message, nil)
+    raise self.class.not_resolved
   end
 
   def [](key)

--- a/lib/hocon/impl/config_impl.rb
+++ b/lib/hocon/impl/config_impl.rb
@@ -27,7 +27,7 @@ class Hocon::Impl::ConfigImpl
 
   def self.improve_not_resolved(what, original)
     new_message = "#{what.render} has not been resolved, you need to call Config#resolve, see API docs for Config#resolve"
-    if new_message == original.get_message
+    if new_message == original.message
       return original
     else
       return ConfigNotResolvedError.new(new_message, original)

--- a/lib/hocon/impl/config_reference.rb
+++ b/lib/hocon/impl/config_reference.rb
@@ -74,17 +74,12 @@ class Hocon::Impl::ConfigReference < Hocon::Impl::AbstractConfigValue
 
   end
 
-  def self.not_resolved
-    error_message = "need to Config#resolve, see the API docs for Config#resolve; substitution not resolved: #{self}"
-    Hocon::ConfigError::ConfigNotResolvedError.new(error_message, nil)
-  end
-
   def value_type
-    raise self.class.not_resolved
+    raise not_resolved
   end
 
   def unwrapped
-    raise self.class.not_resolved
+    raise not_resolved
   end
 
   def new_copy(new_origin)
@@ -100,7 +95,7 @@ class Hocon::Impl::ConfigReference < Hocon::Impl::AbstractConfigValue
   end
 
   def relativized(prefix)
-    new_expr = @expr.change_path(@expr.path,prepend(prefix))
+    new_expr = @expr.change_path(@expr.path.prepend(prefix))
 
     Hocon::Impl::ConfigReference.new(origin, new_expr, @prefix_length + prefix.length)
   end
@@ -123,6 +118,13 @@ class Hocon::Impl::ConfigReference < Hocon::Impl::AbstractConfigValue
 
   def render_value_to_sb(sb, indent, at_root, options)
     sb << @expr.to_s
+  end
+
+  private
+
+  def not_resolved
+    error_message = "need to Config#resolve, see the API docs for Config#resolve; substitution not resolved: #{self}"
+    Hocon::ConfigError::ConfigNotResolvedError.new(error_message, nil)
   end
 
 end

--- a/lib/hocon/impl/replaceable_merge_stack.rb
+++ b/lib/hocon/impl/replaceable_merge_stack.rb
@@ -1,0 +1,4 @@
+require 'hocon/impl'
+
+module Hocon::Impl::ReplaceableMergeStack
+end

--- a/lib/hocon/impl/simple_config_list.rb
+++ b/lib/hocon/impl/simple_config_list.rb
@@ -152,4 +152,8 @@ class Hocon::Impl::SimpleConfigList < Hocon::Impl::AbstractConfigValue
   def new_copy(origin)
     Hocon::Impl::SimpleConfigList.new(origin, @value)
   end
+
+  def include_all?(value_list)
+    value_list.all? { |v| @value.include?(v)}
+  end
 end

--- a/lib/hocon/impl/simple_config_list.rb
+++ b/lib/hocon/impl/simple_config_list.rb
@@ -5,8 +5,11 @@ require 'hocon/impl/resolve_status'
 require 'hocon/config_value_type'
 require 'hocon/config_error'
 require 'hocon/impl/abstract_config_object'
+require 'forwardable'
 
 class Hocon::Impl::SimpleConfigList < Hocon::Impl::AbstractConfigValue
+  extend Forwardable
+
   ResolveStatus = Hocon::Impl::ResolveStatus
   ConfigBugOrBrokenError = Hocon::ConfigError::ConfigBugOrBrokenError
 
@@ -20,6 +23,8 @@ class Hocon::Impl::SimpleConfigList < Hocon::Impl::AbstractConfigValue
       raise ConfigBugError, "SimpleConfigList created with wrong resolve status: #{self}"
     end
   end
+
+  def_delegators :@value, :[], :include?, :empty?, :size, :index, :rindex, :each, :map
 
   def value_type
     Hocon::ConfigValueType::LIST

--- a/lib/hocon/impl/simple_config_object.rb
+++ b/lib/hocon/impl/simple_config_object.rb
@@ -187,42 +187,6 @@ class Hocon::Impl::SimpleConfigObject < Hocon::Impl::AbstractConfigObject
     Set.new(@value.keys)
   end
 
-  def self.map_hash(m)
-    # the keys have to be sorted, otherwise we could be equal
-    # to another map but have a different hashcode.
-    keys = m.keys.sort
-
-    value_hash = 0
-
-    keys.each do |key|
-      value_hash += m[key].hash
-    end
-
-    41 * (41 + keys.hash) + value_hash
-  end
-
-  def self.map_equals(a, b)
-    # This array comparison works if there are no duplicates, which
-    # the hash keys won't have
-    sets_equal = lambda { |x, y| (x.size == y.size) && (x & y == x) }
-
-    if a == b
-      return true
-    end
-
-    if not sets_equal.call(a.keys, b.keys)
-      return false
-    end
-
-    a.keys.each do |key|
-      if a[key] != b[key]
-        return false
-      end
-    end
-
-    true
-  end
-
   def can_equal(other)
     other.is_a? Hocon::Impl::AbstractConfigObject
   end
@@ -339,5 +303,40 @@ class Hocon::Impl::SimpleConfigObject < Hocon::Impl::AbstractConfigObject
     else
       SimpleConfigObject.new(origin, {})
     end
+  end
+
+  private
+
+  def self.map_hash(m)
+    # the keys have to be sorted, otherwise we could be equal
+    # to another map but have a different hashcode.
+    keys = m.keys.sort
+
+    value_hash = 0
+
+    keys.each do |key|
+      value_hash += m[key].hash
+    end
+
+    41 * (41 + keys.hash) + value_hash
+  end
+
+  def self.map_equals(a, b)
+    if a == b
+      return true
+    end
+
+    # Hashes aren't ordered in ruby, so sort first
+    if not a.keys.sort == b.keys.sort
+      return false
+    end
+
+    a.keys.each do |key|
+      if a[key] != b[key]
+        return false
+      end
+    end
+
+    true
   end
 end

--- a/lib/hocon/impl/simple_config_origin.rb
+++ b/lib/hocon/impl/simple_config_origin.rb
@@ -173,4 +173,29 @@ class Hocon::Impl::SimpleConfigOrigin
     @comments_or_nil || []
   end
 
+  def ==(other)
+    if other.is_a? Hocon::Impl::SimpleConfigOrigin
+      @description == other.description &&
+          @line_number == other.line_number &&
+          @end_line_number == other.end_line_number &&
+          @origin_type == other.origin_type &&
+          Hocon::Impl::ConfigImplUtil.equals_handling_nil?(@url_or_nil, other.url_or_nil)
+    else
+      false
+    end
+  end
+
+  def hash
+    h = 41 * (41 + @description.hash)
+    h = 41 * (h + @line_number)
+    h = 41 * (h + @end_line_number)
+    h = 41 * (h + @origin_type.hash)
+
+    unless @url_or_nil.nil?
+      h = 41 * (h + @url_or_nil.hash)
+    end
+
+    h
+  end
+
 end

--- a/lib/hocon/impl/substitution_expression.rb
+++ b/lib/hocon/impl/substitution_expression.rb
@@ -1,0 +1,38 @@
+require 'hocon/impl'
+
+
+class Hocon::Impl::SubstitutionExpression
+
+  def initialize(path, optional)
+    @path = path
+    @optional = optional
+  end
+  attr_reader :path, :optional
+
+  def change_path(new_path)
+    if new_path == @path
+      self
+    else
+      Hocon::Impl::SubstitutionExpression.new(new_path, @optional)
+    end
+  end
+
+  def to_s
+    "${#{@optional ? "?" : ""}#{@path.render}}"
+  end
+
+  def ==(other)
+    if other.is_a? Hocon::Impl::SubstitutionExpression
+      other.path == @path && other.optional == @optional
+    else
+      false
+    end
+  end
+
+  def hash
+    h = 41 * (41 + @path.hash)
+    h = 41 * (h + (optional ? 1 : 0))
+
+    h
+  end
+end

--- a/spec/test_utils.rb
+++ b/spec/test_utils.rb
@@ -313,42 +313,42 @@ module TestUtils
   ##################
   # ConfigValue helpers
   ##################
-  def TestUtils.int_value(value)
+  def self.int_value(value)
     ConfigInt.new(fake_origin, value, nil)
   end
 
-  def TestUtils.float_value(value)
+  def self.float_value(value)
     ConfigFloat.new(fake_origin, value, nil)
   end
 
-  def TestUtils.string_value(value)
+  def self.string_value(value)
     ConfigString.new(fake_origin, value)
   end
 
-  def TestUtils.null_value
+  def self.null_value
     ConfigNull.new(fake_origin)
   end
 
-  def TestUtils.bool_value(value)
+  def self.bool_value(value)
     ConfigBoolean.new(fake_origin, value)
   end
 
-  def TestUtils.config_map(input_map)
+  def self.config_map(input_map)
     # Turns {String: Int} maps into {String: ConfigInt} maps
     Hash[ input_map.map { |k, v| [k, int_value(v)] } ]
   end
 
-  def TestUtils.subst(ref, optional = false)
+  def self.subst(ref, optional = false)
     path = Path.new_path(ref)
     ConfigReference.new(fake_origin, SubstitutionExpression.new(path, optional))
   end
 
-  def TestUtils.subst_in_string(ref, optional = false)
+  def self.subst_in_string(ref, optional = false)
     pieces = [string_value("start<"), subst(ref, optional), string_value(">end")]
     ConfigConcatenation.new(fake_origin, pieces)
   end
 
-  def TestUtils.parse_config(config_string)
+  def self.parse_config(config_string)
     options = Hocon::ConfigParseOptions.defaults
     options.origin_description = "test string"
     options.syntax = Hocon::ConfigSyntax::CONF
@@ -382,7 +382,7 @@ module TestUtils
   ##################
   # RSpec Tests
   ##################
-  def TestUtils.check_equal_objects(first_object, second_object)
+  def self.check_equal_objects(first_object, second_object)
     it "should find the two objects to be equal" do
       not_equal_to_anything_else = TestUtils::NotEqualToAnythingElse.new
 
@@ -402,7 +402,7 @@ module TestUtils
     end
   end
 
-  def TestUtils.check_not_equal_objects(first_object, second_object)
+  def self.check_not_equal_objects(first_object, second_object)
 
     it "should find the two objects to be not equal" do
       not_equal_to_anything_else = TestUtils::NotEqualToAnythingElse.new

--- a/spec/unit/typesafe/config/config_value_spec.rb
+++ b/spec/unit/typesafe/config/config_value_spec.rb
@@ -335,7 +335,7 @@ describe "ConfigConcatenation equality" do
   end
 end
 
-describe "ConfigDeflayedMerge equality" do
+describe "ConfigDelayedMerge equality" do
   s1 = TestUtils.subst("foo")
   s2 = TestUtils.subst("bar")
   a = ConfigDelayedMerge.new(TestUtils.fake_origin, [s1, s2])
@@ -442,6 +442,7 @@ describe "ConfigList" do
     expect(l.include? TestUtils.string_value("a")).to be_truthy
     expect(l.include_all?([TestUtils.string_value("a")])).to be_truthy
     expect(l.include_all?([TestUtils.string_value("b")])).to be_truthy
+    expect(l.include_all?(values)).to be_truthy
 
     expect(l.index(values[1])).to eq(1)
 

--- a/spec/unit/typesafe/config/config_value_spec.rb
+++ b/spec/unit/typesafe/config/config_value_spec.rb
@@ -71,10 +71,10 @@ describe "ConfigInt equality" do
 end
 
 describe "ConfigFloat equality" do
-  context "different ConfigInts with the same value should be equal" do
-    a = TestUtils.float_value(42)
-    same_as_a = TestUtils.float_value(42)
-    b = TestUtils.float_value(43)
+  context "different ConfigFloats with the same value should be equal" do
+    a = TestUtils.float_value(3.14)
+    same_as_a = TestUtils.float_value(3.14)
+    b = TestUtils.float_value(4.14)
 
     context "a equals a" do
       let(:first_object) { a }
@@ -440,6 +440,8 @@ describe "ConfigList" do
     expect(values[2]).to eq(l[2])
 
     expect(l.include? TestUtils.string_value("a")).to be_truthy
+    expect(l.include_all?([TestUtils.string_value("a")])).to be_truthy
+    expect(l.include_all?([TestUtils.string_value("b")])).to be_truthy
 
     expect(l.index(values[1])).to eq(1)
 
@@ -453,9 +455,9 @@ describe "ConfigList" do
 
     expect { l.push(TestUtils.int_value(3)) }.to raise_error(NoMethodError)
     expect { l << TestUtils.int_value(3) }.to raise_error(NoMethodError)
+    expect { l.clear }.to raise_error(NoMethodError)
     expect { l.delete(TestUtils.int_value(2)) }.to raise_error(NoMethodError)
     expect { l.delete(1) }.to raise_error(NoMethodError)
-    expect { l.push(TestUtils.int_value(3)) }.to raise_error(NoMethodError)
     expect { l[0] = TestUtils.int_value(42) }.to raise_error(NoMethodError)
   end
 end

--- a/spec/unit/typesafe/config/config_value_spec.rb
+++ b/spec/unit/typesafe/config/config_value_spec.rb
@@ -1,0 +1,503 @@
+require 'spec_helper'
+require 'hocon'
+require 'test_utils'
+
+require 'hocon/impl/config_delayed_merge'
+require 'hocon/impl/config_delayed_merge_object'
+
+
+
+SimpleConfigOrigin = Hocon::Impl::SimpleConfigOrigin
+SimpleConfigObject = Hocon::Impl::SimpleConfigObject
+SimpleConfigList = Hocon::Impl::SimpleConfigList
+SubstitutionExpression = Hocon::Impl::SubstitutionExpression
+ConfigReference = Hocon::Impl::ConfigReference
+ConfigConcatenation = Hocon::Impl::ConfigConcatenation
+ConfigDelayedMerge = Hocon::Impl::ConfigDelayedMerge
+ConfigDelayedMergeObject = Hocon::Impl::ConfigDelayedMergeObject
+ConfigNotResolvedError = Hocon::ConfigError::ConfigNotResolvedError
+AbstractConfigObject = Hocon::Impl::AbstractConfigObject
+
+describe "SimpleConfigOrigin equality" do
+  context "different origins with the same name should be equal" do
+    let(:a) { SimpleConfigOrigin.new_simple("foo") }
+    let(:same_as_a) { SimpleConfigOrigin.new_simple("foo") }
+    let(:b) { SimpleConfigOrigin.new_simple("bar") }
+
+    context "a equals a" do
+      let(:first_object) { a }
+      let(:second_object) { a }
+      include_examples "object_equality"
+    end
+
+    context "a equals same_as_a" do
+      let(:first_object) { a }
+      let(:second_object) { same_as_a }
+      include_examples "object_equality"
+    end
+
+    context "a does not equal b" do
+      let(:first_object) { a }
+      let(:second_object) { b }
+      include_examples "object_inequality"
+    end
+  end
+end
+
+describe "ConfigInt equality" do
+  context "different ConfigInts with the same value should be equal" do
+    a = TestUtils.int_value(42)
+    same_as_a = TestUtils.int_value(42)
+    b = TestUtils.int_value(43)
+
+    context "a equals a" do
+      let(:first_object) { a }
+      let(:second_object) { a }
+      include_examples "object_equality"
+    end
+
+    context "a equals same_as_a" do
+      let(:first_object) { a }
+      let(:second_object) { same_as_a }
+      include_examples "object_equality"
+    end
+
+    context "a does not equal b" do
+      let(:first_object) { a }
+      let(:second_object) { b }
+      include_examples "object_inequality"
+    end
+  end
+end
+
+describe "ConfigFloat equality" do
+  context "different ConfigInts with the same value should be equal" do
+    a = TestUtils.float_value(42)
+    same_as_a = TestUtils.float_value(42)
+    b = TestUtils.float_value(43)
+
+    context "a equals a" do
+      let(:first_object) { a }
+      let(:second_object) { a }
+      include_examples "object_equality"
+    end
+
+    context "a equals same_as_a" do
+      let(:first_object) { a }
+      let(:second_object) { same_as_a }
+      include_examples "object_equality"
+    end
+
+    context "a does not equal b" do
+      let(:first_object) { a }
+      let(:second_object) { b }
+      include_examples "object_inequality"
+    end
+  end
+end
+
+describe "ConfigFloat and ConfigInt equality" do
+  context "different ConfigInts with the same value should be equal" do
+    float_val = TestUtils.float_value(3.0)
+    int_value = TestUtils.int_value(3)
+    float_value_b = TestUtils.float_value(4.0)
+    int_value_b = TestUtils.float_value(4)
+
+    context "int equals float" do
+      let(:first_object) { float_val }
+      let(:second_object) { int_value }
+      include_examples "object_equality"
+    end
+
+    context "ConfigFloat made from int equals float" do
+      let(:first_object) { float_value_b }
+      let(:second_object) { int_value_b }
+      include_examples "object_equality"
+    end
+
+    context "3 doesn't equal 4.0" do
+      let(:first_object) { int_value }
+      let(:second_object) { float_value_b }
+      include_examples "object_inequality"
+    end
+
+    context "4.0 doesn't equal 3.0" do
+      let(:first_object) { int_value_b }
+      let(:second_object) { float_val }
+      include_examples "object_inequality"
+    end
+  end
+end
+
+describe "SimpleConfigObject equality" do
+  context "SimpleConfigObjects made from hash maps" do
+    a_map = TestUtils.config_map({a: 1, b: 2, c: 3})
+    same_as_a_map = TestUtils.config_map({a: 1, b: 2, c: 3})
+    b_map = TestUtils.config_map({a: 3, b: 4, c: 5})
+
+    # different keys is a different case in the equals implementation
+    c_map = TestUtils.config_map({x: 3, y: 4, z: 5})
+
+    a = SimpleConfigObject.new(TestUtils.fake_origin, a_map)
+    same_as_a = SimpleConfigObject.new(TestUtils.fake_origin, same_as_a_map)
+    b = SimpleConfigObject.new(TestUtils.fake_origin, b_map)
+    c = SimpleConfigObject.new(TestUtils.fake_origin, c_map)
+
+    # the config for an equal object is also equal
+    config = a.to_config
+
+    context "a equals a" do
+      let(:first_object) { a }
+      let(:second_object) { a }
+      include_examples "object_equality"
+    end
+
+    context "a equals same_as_a" do
+      let(:first_object) { a }
+      let(:second_object) { same_as_a }
+      include_examples "object_equality"
+    end
+
+    context "b equals b" do
+      let(:first_object) { b }
+      let(:second_object) { b }
+      include_examples "object_equality"
+    end
+
+    context "c equals c" do
+      let(:first_object) { c }
+      let(:second_object) { c }
+      include_examples "object_equality"
+    end
+
+    context "a doesn't equal b" do
+      let(:first_object) { a }
+      let(:second_object) { b }
+      include_examples "object_inequality"
+    end
+
+    context "a doesn't equal c" do
+      let(:first_object) { a }
+      let(:second_object) { c }
+      include_examples "object_inequality"
+    end
+
+    context "b doesn't equal c" do
+      let(:first_object) { b }
+      let(:second_object) { c }
+      include_examples "object_inequality"
+    end
+
+    context "a's config equals a's config" do
+      let(:first_object) { config }
+      let(:second_object) { config }
+      include_examples "object_equality"
+    end
+
+    context "a's config equals same_as_a's config" do
+      let(:first_object) { config }
+      let(:second_object) { same_as_a.to_config }
+      include_examples "object_equality"
+    end
+
+    context "a's config equals a's config computed again" do
+      let(:first_object) { config }
+      let(:second_object) { a.to_config }
+      include_examples "object_equality"
+    end
+
+    context "a's config doesn't equal b's config" do
+      let(:first_object) { config }
+      let(:second_object) { b.to_config }
+      include_examples "object_inequality"
+    end
+
+    context "a's config doesn't equal c's config" do
+      let(:first_object) { config }
+      let(:second_object) { c.to_config }
+      include_examples "object_inequality"
+    end
+
+    context "a doesn't equal a's config" do
+      let(:first_object) { a }
+      let(:second_object) { config }
+      include_examples "object_inequality"
+    end
+
+    context "b doesn't equal b's config" do
+      let(:first_object) { b }
+      let(:second_object) { b.to_config }
+      include_examples "object_inequality"
+    end
+  end
+end
+
+describe "SimpleConfigList equality" do
+  a_values = [1, 2, 3].map { |i| TestUtils.int_value(i) }
+  a_list = SimpleConfigList.new(TestUtils.fake_origin, a_values)
+
+  same_as_a_values = [1, 2, 3].map { |i| TestUtils.int_value(i) }
+  same_as_a_list = SimpleConfigList.new(TestUtils.fake_origin, same_as_a_values)
+
+  b_values = [4, 5, 6].map { |i| TestUtils.int_value(i) }
+  b_list = SimpleConfigList.new(TestUtils.fake_origin, b_values)
+
+  context "a_list equals a_list" do
+    let(:first_object) { a_list }
+    let(:second_object) { a_list }
+    include_examples "object_equality"
+  end
+
+  context "a_list equals same_as_a_list" do
+    let(:first_object) { a_list }
+    let(:second_object) { same_as_a_list }
+    include_examples "object_equality"
+  end
+
+  context "a_list doesn't equal b_list" do
+    let(:first_object) { a_list }
+    let(:second_object) { b_list }
+    include_examples "object_inequality"
+  end
+end
+
+describe "ConfigReference equality" do
+  a = TestUtils.subst("foo")
+  same_as_a = TestUtils.subst("foo")
+  b = TestUtils.subst("bar")
+  c = TestUtils.subst("foo", true)
+
+  specify "testing values are of the right type" do
+    expect(a).to be_instance_of(ConfigReference)
+    expect(b).to be_instance_of(ConfigReference)
+    expect(c).to be_instance_of(ConfigReference)
+  end
+
+  context "a equals a" do
+    let(:first_object) { a }
+    let(:second_object) { a }
+    include_examples "object_equality"
+  end
+
+  context "a equals same_as_a" do
+    let(:first_object) { a }
+    let(:second_object) { same_as_a }
+    include_examples "object_equality"
+  end
+
+  context "a doesn't equal b" do
+    let(:first_object) { a }
+    let(:second_object) { b }
+    include_examples "object_inequality"
+  end
+
+  context "a doesn't equal c, an optional substitution" do
+    let(:first_object) { a }
+    let(:second_object) { c }
+    include_examples "object_inequality"
+  end
+end
+
+describe "ConfigConcatenation equality" do
+  a = TestUtils.subst_in_string("foo")
+  same_as_a = TestUtils.subst_in_string("foo")
+  b = TestUtils.subst_in_string("bar")
+  c = TestUtils.subst_in_string("foo", true)
+
+  specify "testing values are of the right type" do
+    expect(a).to be_instance_of(ConfigConcatenation)
+    expect(b).to be_instance_of(ConfigConcatenation)
+    expect(c).to be_instance_of(ConfigConcatenation)
+  end
+
+  context "a equals a" do
+    let(:first_object) { a }
+    let(:second_object) { a }
+    include_examples "object_equality"
+  end
+
+  context "a equals same_as_a" do
+    let(:first_object) { a }
+    let(:second_object) { same_as_a }
+    include_examples "object_equality"
+  end
+
+  context "a doesn't equal b" do
+    let(:first_object) { a }
+    let(:second_object) { b }
+    include_examples "object_inequality"
+  end
+
+  context "a doesn't equal c, an optional substitution" do
+    let(:first_object) { a }
+    let(:second_object) { c }
+    include_examples "object_inequality"
+  end
+end
+
+describe "ConfigDeflayedMerge equality" do
+  s1 = TestUtils.subst("foo")
+  s2 = TestUtils.subst("bar")
+  a = ConfigDelayedMerge.new(TestUtils.fake_origin, [s1, s2])
+  same_as_a = ConfigDelayedMerge.new(TestUtils.fake_origin, [s1, s2])
+  b = ConfigDelayedMerge.new(TestUtils.fake_origin, [s2, s1])
+
+  context "a equals a" do
+    let(:first_object) { a }
+    let(:second_object) { a }
+    include_examples "object_equality"
+  end
+
+  context "a equals same_as_a" do
+    let(:first_object) { a }
+    let(:second_object) { same_as_a }
+    include_examples "object_equality"
+  end
+
+  context "a doesn't equal b" do
+    let(:first_object) { a }
+    let(:second_object) { b }
+    include_examples "object_inequality"
+  end
+end
+
+describe "ConfigDelayedMergeObject equality" do
+  empty = SimpleConfigObject.empty
+  s1 = TestUtils.subst("foo")
+  s2 = TestUtils.subst("bar")
+  a = ConfigDelayedMergeObject.new(TestUtils.fake_origin, [empty, s1, s2])
+  same_as_a = ConfigDelayedMergeObject.new(TestUtils.fake_origin, [empty, s1, s2])
+  b = ConfigDelayedMergeObject.new(TestUtils.fake_origin, [empty, s2, s1])
+
+  context "a equals a" do
+    let(:first_object) { a }
+    let(:second_object) { a }
+    include_examples "object_equality"
+  end
+
+  context "a equals same_as_a" do
+    let(:first_object) { a }
+    let(:second_object) { same_as_a }
+    include_examples "object_equality"
+  end
+
+  context "a doesn't equal b" do
+    let(:first_object) { a }
+    let(:second_object) { b }
+    include_examples "object_inequality"
+  end
+end
+
+describe "ConfigObject" do
+  specify "should unwrap correctly" do
+    m = SimpleConfigObject.new(TestUtils.fake_origin, TestUtils.config_map({a: 1, b: 2, c: 3}))
+
+    expect({a: 1, b: 2, c: 3}).to eq(m.unwrapped)
+  end
+
+  specify "should implement read only map" do
+    m = SimpleConfigObject.new(TestUtils.fake_origin, TestUtils.config_map({a: 1, b: 2, c: 3}))
+
+    expect(TestUtils.int_value(1)).to eq(m[:a])
+    expect(TestUtils.int_value(2)).to eq(m[:b])
+    expect(TestUtils.int_value(3)).to eq(m[:c])
+    expect(m[:d]).to be_nil
+    # [] can take a non-string
+    expect(m[[]]).to be_nil
+
+    expect(m.has_key? :a).to be_truthy
+    expect(m.has_key? :z).to be_falsey
+    # has_key? can take a non-string
+    expect(m.has_key? []).to be_falsey
+
+    expect(m.has_value? TestUtils.int_value(1)).to be_truthy
+    expect(m.has_value? TestUtils.int_value(10)).to be_falsey
+    # has_value? can take a non-string
+    expect(m.has_value? []).to be_falsey
+
+    expect(m.empty?).to be_falsey
+
+    expect(m.size).to eq(3)
+
+    values = [TestUtils.int_value(1), TestUtils.int_value(2), TestUtils.int_value(3)]
+    expect(values).to eq(m.values)
+
+    keys = [:a, :b, :c]
+    expect(keys).to eq(m.keys)
+
+    expect { m["hello"] = TestUtils.int_value(41) }.to raise_error(NoMethodError)
+    expect { m.delete(:a) }.to raise_error(NoMethodError)
+  end
+end
+
+describe "ConfigList" do
+  specify "should implement read only list" do
+    values = ["a", "b", "c"].map { |i| TestUtils.string_value(i) }
+    l = SimpleConfigList.new(TestUtils.fake_origin, values)
+
+    expect(values[0]).to eq(l[0])
+    expect(values[1]).to eq(l[1])
+    expect(values[2]).to eq(l[2])
+
+    expect(l.include? TestUtils.string_value("a")).to be_truthy
+
+    expect(l.index(values[1])).to eq(1)
+
+    expect(l.empty?).to be_falsey
+
+    expect(l.map { |v| v }).to eq(values.map { |v| v })
+
+    expect(l.rindex(values[1])).to eq(1)
+
+    expect(l.size).to eq(3)
+
+    expect { l.push(TestUtils.int_value(3)) }.to raise_error(NoMethodError)
+    expect { l << TestUtils.int_value(3) }.to raise_error(NoMethodError)
+    expect { l.delete(TestUtils.int_value(2)) }.to raise_error(NoMethodError)
+    expect { l.delete(1) }.to raise_error(NoMethodError)
+    expect { l.push(TestUtils.int_value(3)) }.to raise_error(NoMethodError)
+    expect { l[0] = TestUtils.int_value(42) }.to raise_error(NoMethodError)
+  end
+end
+
+describe "Objects throwing ConfigNotResolvedError" do
+  context "ConfigSubstitution" do
+    specify "should throw ConfigNotResolvedError" do
+      expect{ TestUtils.subst("foo").value_type }.to raise_error(ConfigNotResolvedError)
+      expect{ TestUtils.subst("foo").unwrapped }.to raise_error(ConfigNotResolvedError)
+    end
+  end
+
+  context "ConfigDelayedMerge" do
+    let(:dm) { ConfigDelayedMerge.new(TestUtils.fake_origin, [TestUtils.subst("a"), TestUtils.subst("b")]) }
+
+    specify "should throw ConfigNotResolvedError" do
+      expect{ dm.value_type }.to raise_error(ConfigNotResolvedError)
+      expect{ dm.unwrapped }.to raise_error(ConfigNotResolvedError)
+    end
+  end
+
+  context "ConfigDelayedMergeObject" do
+    empty_object = SimpleConfigObject.empty
+    objects = [empty_object, TestUtils.subst("a"), TestUtils.subst("b")]
+
+    let(:dmo) { ConfigDelayedMergeObject.new(TestUtils.fake_origin, objects) }
+
+    specify "should have value type of OBJECT" do
+      expect(dmo.value_type).to eq(Hocon::ConfigValueType::OBJECT)
+    end
+
+    specify "should throw ConfigNotResolvedError" do
+      expect{ dmo.unwrapped }.to raise_error(ConfigNotResolvedError)
+      expect{ dmo["foo"] }.to raise_error(ConfigNotResolvedError)
+      expect{ dmo.has_key?(nil) }.to raise_error(ConfigNotResolvedError)
+      expect{ dmo.has_value?(nil) }.to raise_error(ConfigNotResolvedError)
+      expect{ dmo.each }.to raise_error(ConfigNotResolvedError)
+      expect{ dmo.empty? }.to raise_error(ConfigNotResolvedError)
+      expect{ dmo.keys }.to raise_error(ConfigNotResolvedError)
+      expect{ dmo.size }.to raise_error(ConfigNotResolvedError)
+      expect{ dmo.values }.to raise_error(ConfigNotResolvedError)
+      expect{ dmo.to_config.get_int("foo") }.to raise_error(ConfigNotResolvedError)
+    end
+  end
+end


### PR DESCRIPTION
This is a partial set of the tests for ConfigValueTest.scala
We're going to get whatever functionality I've implemented in this PR so others can use it and
avoid creating merge conflicts.

The rest of the PRs will come as much smaller chunks of effort

This branch was rebased on top of @KevinCorcoran's tk-162 PR, and hopefully I merged my changes into it without breaking anything the tests didn't catch.

Implemented parts of:
  ConfigDelayedMerge
  ConfigDelayedMergeObject
  ConfigReference
  ReplaceableMergeStack module

SimpleConfigList/Object now behave like arrays/hashes by delegating required functions to their @value attribute

Implemented ==() and hash() for a bunch of classes

Many other small changes