### PR TITLE
(TK-160) Port minimal `include` functionality

### DIFF
--- a/lib/hocon/config_error.rb
+++ b/lib/hocon/config_error.rb
@@ -22,6 +22,12 @@ class Hocon::ConfigError < StandardError
     end
   end
 
+  class ConfigIOError < Hocon::ConfigError
+    def initialize(origin, message, cause = nil)
+      super(origin, message, cause)
+    end
+  end
+
   class ConfigParseError < Hocon::ConfigError
   end
 

--- a/lib/hocon/config_parse_options.rb
+++ b/lib/hocon/config_parse_options.rb
@@ -16,10 +16,6 @@ class Hocon::ConfigParseOptions
     @includer = includer
   end
 
-  def allow_missing?
-    @allow_missing
-  end
-
   def set_syntax(syntax)
     if @syntax == syntax
       self
@@ -40,6 +36,21 @@ class Hocon::ConfigParseOptions
                                     @allow_missing,
                                     @includer)
     end
+  end
+
+  def set_allow_missing(allow_missing)
+    if allow_missing? == allow_missing
+      self
+    else
+      Hocon::ConfigParseOptions.new(@syntax,
+                                    @origin_description,
+                                    allow_missing,
+                                    @includer)
+    end
+  end
+
+  def allow_missing?
+    @allow_missing
   end
 
   def set_includer(includer)

--- a/lib/hocon/config_value_type.rb
+++ b/lib/hocon/config_value_type.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
 
 require 'hocon'
+require 'hocon/config_error'
 
 #
 # The type of a configuration value (following the <a
@@ -22,7 +23,7 @@ module Hocon::ConfigValueType
       when BOOLEAN then "BOOLEAN"
       when NULL then "NULL"
       when STRING then "STRING"
-      else raise ConfigBugError, "Unrecognized value type '#{config_value_type}'"
+      else raise Hocon::ConfigError::ConfigBugOrBrokenError, "Unrecognized value type '#{config_value_type}'"
     end
   end
 end

--- a/lib/hocon/impl/abstract_config_object.rb
+++ b/lib/hocon/impl/abstract_config_object.rb
@@ -39,7 +39,7 @@ class Hocon::Impl::AbstractConfigObject < Hocon::Impl::AbstractConfigValue
 
   def merge_origins(stack)
     if stack.empty?
-      raise ConfigBugError, "can't merge origins on empty list"
+      raise ConfigBugOrBrokenError, "can't merge origins on empty list"
     end
     origins = []
     first_origin = nil

--- a/lib/hocon/impl/abstract_config_value.rb
+++ b/lib/hocon/impl/abstract_config_value.rb
@@ -9,6 +9,7 @@ require 'hocon/impl/resolve_result'
 require 'hocon/impl/unmergeable'
 require 'hocon/impl/abstract_config_object'
 require 'hocon/impl/config_impl_util'
+require 'hocon/config_error'
 
 ##
 ## Trying very hard to avoid a parent reference in config values; when you have
@@ -17,6 +18,7 @@ require 'hocon/impl/config_impl_util'
 ##
 class Hocon::Impl::AbstractConfigValue
   ConfigImplUtil = Hocon::Impl::ConfigImplUtil
+  ConfigBugOrBrokenError = Hocon::ConfigError::ConfigBugOrBrokenError
 
   attr_reader :origin
 
@@ -54,7 +56,7 @@ class Hocon::Impl::AbstractConfigValue
   # mergedWith* if we're ignoring fallbacks.
   def require_not_ignoring_fallbacks
     if ignores_fallbacks?
-      raise ConfigBugError, "method should not have been called with ignoresFallbacks=true #{self.class.name}"
+      raise ConfigBugOrBrokenError, "method should not have been called with ignoresFallbacks=true #{self.class.name}"
     end
   end
 

--- a/lib/hocon/impl/config_concatenation.rb
+++ b/lib/hocon/impl/config_concatenation.rb
@@ -126,7 +126,7 @@ class Hocon::Impl::ConfigConcatenation < Hocon::Impl::AbstractConfigValue
     elsif consolidated.length == 1
       consolidated[0]
     else
-      merged_origin = SimpleConfigOrigin.merge_origins(consolidated)
+      merged_origin = SimpleConfigOrigin.merge_value_origins(consolidated)
       Hocon::Impl::ConfigConcatenation.new(merged_origin, consolidated)
     end
   end

--- a/lib/hocon/impl/config_concatenation.rb
+++ b/lib/hocon/impl/config_concatenation.rb
@@ -68,7 +68,7 @@ class Hocon::Impl::ConfigConcatenation < Hocon::Impl::AbstractConfigValue
       joined = left.concatenate(right)
     elsif (left.is_a?(Hocon::Impl::ConfigConcatenation)) ||
         (right.is_a?(Hocon::Impl::ConfigConcatenation))
-      raise ConfigBugError, "unflattened ConfigConcatenation"
+      raise ConfigBugOrBrokenError, "unflattened ConfigConcatenation"
     elsif (left.is_a?(Unmergeable)) || (right.is_a?(Unmergeable))
       # leave joined=null, cannot join
     else
@@ -191,13 +191,13 @@ class Hocon::Impl::ConfigConcatenation < Hocon::Impl::AbstractConfigValue
     @pieces = pieces
 
     if pieces.size < 2
-      raise ConfigBugError, "Created concatenation with less than 2 items: #{self}"
+      raise ConfigBugOrBrokenError, "Created concatenation with less than 2 items: #{self}"
     end
 
     had_unmergeable = false
     pieces.each do |p|
       if p.is_a?(Hocon::Impl::ConfigConcatenation)
-        raise ConfigBugError, "ConfigConcatenation should never be nested: #{self}"
+        raise ConfigBugOrBrokenError, "ConfigConcatenation should never be nested: #{self}"
       end
       if p.is_a?(Unmergeable)
         had_unmergeable = true
@@ -205,7 +205,7 @@ class Hocon::Impl::ConfigConcatenation < Hocon::Impl::AbstractConfigValue
     end
 
     unless had_unmergeable
-      raise ConfigBugError, "Created concatenation without an unmergeable in it: #{self}"
+      raise ConfigBugOrBrokenError, "Created concatenation without an unmergeable in it: #{self}"
     end
   end
 

--- a/lib/hocon/impl/config_impl.rb
+++ b/lib/hocon/impl/config_impl.rb
@@ -10,7 +10,7 @@ require 'hocon/impl/config_boolean'
 require 'hocon/impl/config_null'
 
 class Hocon::Impl::ConfigImpl
-  @default_includer = Hocon::Impl::SimpleIncluder.new
+  @default_includer = Hocon::Impl::SimpleIncluder.new(nil)
   @default_value_origin = Hocon::Impl::SimpleConfigOrigin.new_simple("hardcoded value")
   @default_true_value = Hocon::Impl::ConfigBoolean.new(@default_value_origin, true)
   @default_false_value = Hocon::Impl::ConfigBoolean.new(@default_value_origin, false)

--- a/lib/hocon/impl/parser.rb
+++ b/lib/hocon/impl/parser.rb
@@ -1106,7 +1106,7 @@ class Hocon::Impl::Parser
     context = Hocon::Impl::Parser::ParseContext.new(
         options.syntax, origin, tokens,
         Hocon::Impl::SimpleIncluder.make_full(options.includer),
-                                        include_context)
+        include_context)
     context.parse
   end
 end

--- a/lib/hocon/impl/parser.rb
+++ b/lib/hocon/impl/parser.rb
@@ -15,6 +15,7 @@ require 'hocon/impl/config_impl_util'
 require 'hocon/impl/tokenizer'
 require 'hocon/impl/simple_config_origin'
 require 'hocon/impl/path'
+require 'hocon/impl/url'
 
 class Hocon::Impl::Parser
   
@@ -23,6 +24,7 @@ class Hocon::Impl::Parser
   ConfigValueType = Hocon::ConfigValueType
   ConfigConcatenation = Hocon::Impl::ConfigConcatenation
   ConfigParseError = Hocon::ConfigError::ConfigParseError
+  ConfigBugorBrokenError = Hocon::ConfigError::ConfigBugOrBrokenError
   SimpleConfigObject = Hocon::Impl::SimpleConfigObject
   SimpleConfigList = Hocon::Impl::SimpleConfigList
   SimpleConfigOrigin = Hocon::Impl::SimpleConfigOrigin
@@ -232,7 +234,7 @@ class Hocon::Impl::Parser
         end
 
         if v.nil?
-          raise ConfigBugError("no value")
+          raise ConfigBugOrBrokenError("no value")
         end
 
         if values.nil?
@@ -342,6 +344,107 @@ class Hocon::Impl::Parser
 
         put_back(t)
         Hocon::Impl::Parser.parse_path_expression(expression, line_origin)
+      end
+    end
+
+    def unquoted_whitespace?(t)
+      if !(Tokens.unquoted_text?(t))
+        return false
+      end
+
+      s = Tokens.unquoted_text(t)
+      
+    end
+
+    def parse_include(values)
+      t = next_token_ignoring_newline
+      while unquoted_whitespace?(t.token)
+        t = next_token_ignoring_newline
+      end
+
+      obj = nil
+
+      # we either have a quoted string or the "file()" syntax
+      if Tokens.unquoted_text?(t.token)
+        kind = Tokens.unquoted_text(t.token)
+
+        if kind == "url("
+        elsif kind == "file("
+        elsif kind == "classpath("
+        else
+          raise parse_error("expecting include parameter to be quoted filename, file(), classpath(), or url(). No spaces are allowed before the open paren. Not expecting: " + t)
+        end
+
+        # skip space inside parens
+        t = next_token_ignoring_newline
+        while unquoted_whitespace?(t.token)
+          t = next_token_ignoring_newline
+        end
+
+        # quoted string
+        name = nil
+        if Tokens.value_with_type?(t.token, ConfigValueType::String)
+          name = Tokens.get_value(t.token).unwrapped
+        else
+          raise parse_error("expecting a quoted string inside file(), classpath(), or url(), rather than: " + t)
+        end
+
+        # skip space after string, inside parens
+        t = next_token_ignoring_newline
+        while unquoted_whitespace(t.token)
+          t = next_token_ignoring_newline
+        end
+
+        if Tokens.unquoted_text?(t.token) && (Tokens.unquoted_text(t.token) == ")")
+          # OK, close paren
+        else
+          raise parse_error("expecting a close parentheses ')' here, not: " + t)
+        end
+
+        if kind == "url("
+          url = nil
+          begin
+            url = Hocon::Impl::Url.new(name)
+          rescue Hocon::Impl::Url::MalformedUrlError => e
+            raise parse_error("include url() specifies an invalid URL: " + name, e)
+          end
+          obj = @includer.include_url(@include_context, url)
+        elsif kind == "file("
+          obj = @includer.include_file(@include_context, File.new(name))
+        elsif kind == "classpath("
+          obj = @includer.include_resources(@include_context, name)
+        else
+          raise ConfigBugOrBrokenError, "should not be reached"
+        end
+      elsif Tokens.value_with_type?(t.token, ConfigValueType::STRING)
+        name = Tokens.value(t.token).unwrapped
+        obj = @includer.include(@include_context, name)
+      else
+        raise parse_error("include keyword is not followed by a quoted string, but by: " + t.to_s)
+      end
+
+      # we really should make this work, but for now throwing an
+      # exception is better than producing an incorrect result.
+      # See https://github.com/typesafehub/config/issues/160
+      if @array_count > 0 && (obj.resolve_status != ResolveStatus::RESOLVED)
+        raise parse_error("Due to current limitations of the config parser, when an include statement is nested inside a list value, " +
+          "${} substitutions inside the included file cannot be resolved correctly. Either move the include outside of the list value or " +
+          "remove the ${} statements from the included file.")
+      end
+
+      if !(@path_stack.is_empty?)
+        prefix = full_current_path
+        obj = obj.relativized(prefix)
+      end
+
+      obj.key_set.each do |key|
+        v = obj.get(key)
+        existing = values.get(key)
+        if !(existing.nil?)
+          values.put(key, v.with_fallback(existing))
+        else
+          values.put(key, v)
+        end
       end
     end
     
@@ -454,7 +557,7 @@ class Hocon::Impl::Parser
             values[key] = new_value
           else
             if @flavor == ConfigSyntax::JSON
-              raise ConfigBugError, "somehow got multi-element path in JSON mode"
+              raise ConfigBugOrBrokenError, "somehow got multi-element path in JSON mode"
             end
 
             obj = create_value_under_path(remaining, new_value)
@@ -566,7 +669,7 @@ class Hocon::Impl::Parser
     def parse
       t = next_token_ignoring_newline
       if t.token != Tokens::START
-        raise ConfigBugError, "token stream did not begin with START, had #{t}"
+        raise ConfigBugOrBrokenError, "token stream did not begin with START, had #{t}"
       end
 
       t = next_token_ignoring_newline
@@ -601,7 +704,7 @@ class Hocon::Impl::Parser
 
     def put_back(token)
       if Tokens.comment?(token.token)
-        raise ConfigBugError, "comment token should have been stripped before it was available to put back"
+        raise ConfigBugOrBrokenError, "comment token should have been stripped before it was available to put back"
       end
       @buffer.push(token)
     end
@@ -655,7 +758,7 @@ class Hocon::Impl::Parser
       else
         if @syntax == ConfigSyntax::JSON
           if Tokens.unquoted_text?(t)
-            raise parse_error(add_key_name("Token not allowed in valid JSON: '#{Tokens.get_unquoted_text(t)}'"))
+            raise parse_error(add_key_name("Token not allowed in valid JSON: '#{Tokens.unquoted_text(t)}'"))
           elsif Tokens.substitution?(t)
             raise parse_error(add_key_name("Substitutions (${} syntax) not allowed in JSON"))
           end
@@ -793,7 +896,7 @@ class Hocon::Impl::Parser
         # comments are supposed to get attached to a token,
         # not put back in the buffer. Assert this as an invariant.
         if Tokens.comment?(@buffer.last.token)
-          raise ConfigBugError, "comment token should not have been in buffer: #{@buffer}"
+          raise ConfigBugOrBrokenError, "comment token should not have been in buffer: #{@buffer}"
         end
         with_preceding_comments
       end
@@ -990,7 +1093,7 @@ class Hocon::Impl::Parser
     context = Hocon::Impl::Parser::ParseContext.new(
         options.syntax, origin, tokens,
         Hocon::Impl::SimpleIncluder.make_full(options.includer),
-        include_context)
+                                        include_context)
     context.parse
   end
 end

--- a/lib/hocon/impl/path_builder.rb
+++ b/lib/hocon/impl/path_builder.rb
@@ -2,6 +2,7 @@
 
 require 'hocon/impl'
 require 'hocon/impl/path'
+require 'hocon/config_error'
 
 class Hocon::Impl::PathBuilder
 
@@ -12,7 +13,7 @@ class Hocon::Impl::PathBuilder
 
   def check_can_append
     if @result
-      raise ConfigBugError, "Adding to PathBuilder after getting result"
+      raise Hocon::ConfigError::ConfigBugOrBrokenError, "Adding to PathBuilder after getting result"
     end
   end
 

--- a/lib/hocon/impl/properties_parser.rb
+++ b/lib/hocon/impl/properties_parser.rb
@@ -28,7 +28,7 @@ class Hocon::Impl::PropertiesParser
       # If we didn't start out as properties, then this is an error.
       value_paths.each do |path|
         if scope_paths.include?(path)
-          raise ConfigBugOrBrokenError.new("In the map, path '#{path.render}' occurs as both" +
+          raise Hocon::ConfigError::ConfigBugOrBrokenError.new("In the map, path '#{path.render}' occurs as both" +
                                            " the parent object of a value and as a value. Because Map " +
                                            "has no defined ordering, this is a broken situation.")
         end

--- a/lib/hocon/impl/resolve_source.rb
+++ b/lib/hocon/impl/resolve_source.rb
@@ -24,7 +24,7 @@ class Hocon::Impl::ResolveSource
 
     if @path_from_root == nil
       if parent.equal?(@root)
-        return ResolveSource.new(@root, Node.new(parent))
+        return self.class.new(@root, Node.new(parent))
       else
         if Hocon::Impl::ConfigImpl.trace_substitution_enabled
           # this hasDescendant check is super-expensive so it's a

--- a/lib/hocon/impl/simple_config_list.rb
+++ b/lib/hocon/impl/simple_config_list.rb
@@ -20,7 +20,7 @@ class Hocon::Impl::SimpleConfigList < Hocon::Impl::AbstractConfigValue
 
     # kind of an expensive debug check (makes this constructor pointless)
     if status != ResolveStatus.from_values(value)
-      raise ConfigBugError, "SimpleConfigList created with wrong resolve status: #{self}"
+      raise ConfigBugOrBrokenError, "SimpleConfigList created with wrong resolve status: #{self}"
     end
   end
 

--- a/lib/hocon/impl/simple_config_object.rb
+++ b/lib/hocon/impl/simple_config_object.rb
@@ -275,6 +275,10 @@ class Hocon::Impl::SimpleConfigObject < Hocon::Impl::AbstractConfigObject
     self.class.new(origin, new_map, ResolveStatus.from_values(new_map.values), @ignores_fallbacks)
   end
 
+  def resolve_status
+    ResolveStatus.from_boolean(@resolved)
+  end
+
   def resolve_substitutions(context, source)
     if resolve_status == ResolveStatus::RESOLVED
       return ResolveResult.make(context, self)

--- a/lib/hocon/impl/simple_config_object.rb
+++ b/lib/hocon/impl/simple_config_object.rb
@@ -29,7 +29,7 @@ class Hocon::Impl::SimpleConfigObject < Hocon::Impl::AbstractConfigObject
                   ignores_fallbacks = false)
     super(origin)
     if value.nil?
-      raise ConfigBugError, "creating config object with null map"
+      raise ConfigBugOrBrokenError, "creating config object with null map"
     end
     @value = value
     @resolved = (status == Hocon::Impl::ResolveStatus::RESOLVED)
@@ -37,7 +37,7 @@ class Hocon::Impl::SimpleConfigObject < Hocon::Impl::AbstractConfigObject
 
     # Kind of an expensive debug check. Comment out?
     if status != Hocon::Impl::ResolveStatus.from_values(value.values)
-      raise ConfigBugError, "Wrong resolved status on #{self}"
+      raise ConfigBugOrBrokenError, "Wrong resolved status on #{self}"
     end
   end
 
@@ -63,7 +63,7 @@ class Hocon::Impl::SimpleConfigObject < Hocon::Impl::AbstractConfigObject
     require_not_ignoring_fallbacks
 
     unless abstract_fallback.is_a?(Hocon::Impl::SimpleConfigObject)
-      raise ConfigBugError, "should not be reached (merging non-SimpleConfigObject)"
+      raise ConfigBugOrBrokenError, "should not be reached (merging non-SimpleConfigObject)"
     end
 
     fallback = abstract_fallback

--- a/lib/hocon/impl/simple_config_origin.rb
+++ b/lib/hocon/impl/simple_config_origin.rb
@@ -3,6 +3,7 @@
 require 'uri'
 require 'hocon/impl'
 require 'hocon/impl/origin_type'
+require 'hocon/config_error'
 
 class Hocon::Impl::SimpleConfigOrigin
 
@@ -98,7 +99,7 @@ class Hocon::Impl::SimpleConfigOrigin
 
   def self.merge_origins(stack)
     if stack.empty?
-      raise ConfigBugError, "can't merge empty list of origins"
+      raise Hocon::ConfigError::ConfigBugOrBrokenError, "can't merge empty list of origins"
     elsif stack.length == 1
       stack[0]
     elsif stack.length == 2

--- a/lib/hocon/impl/simple_include_context.rb
+++ b/lib/hocon/impl/simple_include_context.rb
@@ -1,9 +1,14 @@
 # encoding: utf-8
 
 require 'hocon/impl'
+require 'hocon/impl/simple_includer'
 
 class Hocon::Impl::SimpleIncludeContext
   def initialize(parseable)
     @parseable = parseable
+  end
+
+  def parse_options
+    Hocon::Impl::SimpleIncluder.clear_for_include(@parseable.options)
   end
 end

--- a/lib/hocon/impl/simple_includer.rb
+++ b/lib/hocon/impl/simple_includer.rb
@@ -1,9 +1,163 @@
 # encoding: utf-8
 
+require 'stringio'
 require 'hocon/impl'
 require 'hocon/impl/full_includer'
+require 'hocon/impl/url'
+require 'hocon/impl/config_impl'
+require 'hocon/config_error'
+require 'hocon/config_syntax'
+require 'hocon/impl/simple_config_object'
+require 'hocon/impl/simple_config_origin'
 
 class Hocon::Impl::SimpleIncluder < Hocon::Impl::FullIncluder
+
+  ConfigBugorBrokenError = Hocon::ConfigError::ConfigBugOrBrokenError
+  ConfigIOError = Hocon::ConfigError::ConfigIOError
+  SimpleConfigObject = Hocon::Impl::SimpleConfigObject
+  SimpleConfigOrigin = Hocon::Impl::SimpleConfigOrigin
+
+
+  def initialize(fallback)
+    @fallback = fallback
+  end
+
+  # ConfigIncludeContext does this for us on its options
+  def self.clear_for_include(options)
+    # the class loader and includer are inherited, but not this other stuff
+    options.set_syntax(nil).set_origin_description(nil).set_allow_missing(true)
+  end
+
+
+  # this is the heuristic includer
+  def include(context, name)
+    obj = self.class.include_without_fallback(context, name)
+
+    # now use the fallback includer if any and merge its result
+    if ! (@fallback.nil?)
+      obj.with_fallback(@fallback.include(context, name))
+    else
+      obj
+    end
+  end
+
+  # the heuristic includer in static form
+  def self.include_without_fallback(context, name)
+    # the heuristic is valid URL then URL, else relative to including file;
+    # relativeTo in a file falls back to classpath inside relativeTo().
+
+    url = nil
+    begin
+      url = Hocon::Impl::Url.new(name)
+    rescue Hocon::Impl::Url::MalformedUrlError => e
+      url = nil
+    end
+
+    if !(url.nil?)
+      include_url_without_fallback(context, url)
+    else
+      source = RelativeNameSource.new(context)
+      from_basename(source, name, context.parse_options)
+    end
+  end
+
+  class NameSource
+    def name_to_parseable(name, parse_options)
+      raise Hocon::ConfigError::ConfigBugOrBrokenError,
+            "name_to_parseable must be implemented by subclass"
+    end
+  end
+
+  class RelativeNameSource < NameSource
+    def initialize(context)
+      @context = context
+    end
+  end
+
+  # this function is a little tricky because there are three places we're
+  # trying to use it; for 'include "basename"' in a .conf file, for
+  # loading app.{conf,json,properties} from classpath, and for
+  # loading app.{conf,json,properties} from the filesystem.
+  def self.from_basename(source, name, options)
+    obj = nil
+    if name.end_with?(".conf") || name.end_with?(".json") || name.end_with?(".properties")
+      p = source.name_to_parseable(name, options)
+
+      obj = p.parse(p.options.set_allow_missing(options.allow_missing?))
+    else
+      conf_handle = source.name_to_parseable(name + ".conf", options)
+      json_handle = source.name_to_parseable(name + ".json", options)
+      props_handle = source.name_to_parseable(name + ".properties", options)
+      got_something = false
+      fails = []
+
+      syntax = options.get_syntax
+
+      obj = SimpleConfigObject.empty(SimpleConfigOrigin.new_simple(name))
+      if syntax.nil? || (syntax == Hocon::ConfigSyntax::CONF)
+        begin
+          obj = conf_handle.parse(conf_handle.options.set_allow_missing(false)).
+                  set_syntax(Hocon::ConfigSyntax::CONF)
+          got_something = true
+        rescue ConfigIOError => e
+          fails << e
+        end
+      end
+
+      if syntax.nil? || (syntax == Hocon::ConfigSyntax::JSON)
+        begin
+          parsed = json_handle.parse(json_handle.options.set_allow_missing(false).
+                                         set_syntax(Hocon::ConfigSyntax::JSON))
+          obj = obj.with_fallback(parsed)
+          got_something = true
+        rescue ConfigIOError => e
+          fails << e
+        end
+      end
+
+      if syntax.nil? || (syntax == Hocon::ConfigSyntax::PROPERTIES)
+        begin
+          parsed = props_handle.parse(props_handle.options).set_allow_missing(false).
+                      set_syntax(Hocon::ConfigSyntax::PROPERTIES)
+          obj = obj.with_fallback(parsed)
+          got_something = true
+        rescue ConfigIOError => e
+          fails.add(e)
+        end
+      end
+
+      if (! options.allow_missing?) && (! got_something)
+        if Hocon::Impl::ConfigImpl.trace_loads_enabled
+          # the individual exceptions should have been logged already
+          # with tracing enabled
+          Hocon::Impl::ConfigImpl.trace("Did not find '#{name}'" +
+            " with any extension (.conf, .json, .properties); " +
+            "exceptions should have been logged above.")
+        end
+
+        if fails.empty?
+          # this should not happen
+          raise ConfigBugOrBrokenError, "should not be reached: nothing found but no exceptions thrown"
+        else
+          sb = StringIO.new
+          fails.each do |t|
+            sb << t
+            sb << ", "
+          end
+          raise ConfigIOError.new(SimpleConfigOrigin.new_simple(name), sb.to_s, fails[0])
+        end
+      elsif !got_something
+        if Hocon::Impl::ConfigImpl.trace_loads_enabled
+          Hocon::Impl::ConfigImpl.trace("Did not find '#{name}'" +
+            " with any extension (.conf, .json, .properties); but '#{name}'" +
+            " is allowed to be missing. Exceptions from load attempts should have been logged above.")
+        end
+      end
+    end
+
+    obj
+  end
+
   class Proxy < Hocon::Impl::FullIncluder
     def initialize(delegate)
       @delegate = delegate

--- a/lib/hocon/impl/token_type.rb
+++ b/lib/hocon/impl/token_type.rb
@@ -40,7 +40,7 @@ class Hocon::Impl::TokenType
       when COMMENT then "COMMENT"
       when PLUS_EQUALS then "PLUS_EQUALS"
       when IGNORED_WHITESPACE then "IGNORED_WHITESPACE"
-      else raise ConfigBugError, "Unrecognized token type #{token_type}"
+      else raise ConfigBugOrBrokenError, "Unrecognized token type #{token_type}"
     end
   end
 end

--- a/lib/hocon/impl/tokenizer.rb
+++ b/lib/hocon/impl/tokenizer.rb
@@ -9,6 +9,7 @@ require 'forwardable'
 
 class Hocon::Impl::Tokenizer
   Tokens = Hocon::Impl::Tokens
+  ConfigBugOrBrokenError = Hocon::ConfigError::ConfigBugOrBrokenError
 
   class TokenizerProblemError < StandardError
     def initialize(problem)
@@ -89,7 +90,7 @@ class Hocon::Impl::Tokenizer
 
     def self.problem(origin, what, message, suggest_quotes, cause)
       if what.nil? || message.nil?
-        throw Hocon::ConfigError::ConfigBugOrBrokenError.new("internal error, creating bad TokenizerProblemError")
+        raise ConfigBugOrBrokenError.new("internal error, creating bad TokenizerProblemError")
       end
       TokenizerProblemError.new(Tokens.new_problem(origin, what, message, suggest_quotes, cause))
     end
@@ -147,7 +148,7 @@ class Hocon::Impl::Tokenizer
 
     def put_back(c)
       if @buffer.length > 2
-        raise ConfigBugError, "bug: putBack() three times, undesirable look-ahead"
+        raise ConfigBugOrBrokenError, "bug: putBack() three times, undesirable look-ahead"
       end
       @buffer.push(c)
     end
@@ -227,7 +228,7 @@ class Hocon::Impl::Tokenizer
       if first_char == '/'
         discard = next_char_raw
         if discard != '/'
-          raise ConfigBugError, "called pullComment but // not seen"
+          raise ConfigBugOrBrokenError, "called pullComment but // not seen"
         end
         double_slash = true
       end
@@ -519,7 +520,7 @@ class Hocon::Impl::Tokenizer
         end
 
         if t.nil?
-          raise ConfigBugError, "bug: failed to generate next token"
+          raise ConfigBugOrBrokenError, "bug: failed to generate next token"
         end
 
         t
@@ -544,7 +545,7 @@ class Hocon::Impl::Tokenizer
           @tokens.push(e.problem)
         end
         if @tokens.empty?
-          raise ConfigBugError, "bug: tokens queue should not be empty here"
+          raise ConfigBugOrBrokenError, "bug: tokens queue should not be empty here"
         end
       end
       t

--- a/lib/hocon/impl/tokens.rb
+++ b/lib/hocon/impl/tokens.rb
@@ -20,6 +20,8 @@ class Hocon::Impl::Tokens
   ConfigNull = Hocon::Impl::ConfigNull
   ConfigBoolean = Hocon::Impl::ConfigBoolean
 
+  ConfigBugOrBrokenError = Hocon::ConfigError::ConfigBugOrBrokenError
+
   START = Token.new_without_origin(TokenType::START, "start of file", "")
   EOF = Token.new_without_origin(TokenType::EOF, "end of file", "")
   COMMA = Token.new_without_origin(TokenType::COMMA, "','", ",")
@@ -223,7 +225,7 @@ class Hocon::Impl::Tokens
     if token.is_a?(Problem)
       token.message
     else
-      raise Hocon::ConfigError::ConfigBugOrBrokenError.new("tried to get problem message from #{token}")
+      raise ConfigBugOrBrokenError.new("tried to get problem message from #{token}")
     end
   end
 
@@ -231,7 +233,7 @@ class Hocon::Impl::Tokens
     if token.is_a?(Problem)
       token.suggest_quotes
     else
-      raise Hocon::ConfigError::ConfigBugOrBrokenError.new("tried to get problem suggest_quotes from #{token}")
+      raise ConfigBugOrBrokenError.new("tried to get problem suggest_quotes from #{token}")
     end
   end
 
@@ -239,7 +241,7 @@ class Hocon::Impl::Tokens
     if token.is_a?(Problem)
       token.cause
     else
-      raise Hocon::ConfigError::ConfigBugOrBrokenError.new("tried to get problem cause from #{token}")
+      raise ConfigBugOrBrokenError.new("tried to get problem cause from #{token}")
     end
   end
 
@@ -307,7 +309,7 @@ class Hocon::Impl::Tokens
     if comment?(token)
       token.text
     else
-      raise ConfigBugError, "tried to get comment text from #{token}"
+      raise ConfigBugOrBrokenError, "tried to get comment text from #{token}"
     end
   end
 
@@ -327,7 +329,7 @@ class Hocon::Impl::Tokens
     if unquoted_text?(token)
       token.value
     else
-      raise ConfigBugError, "tried to get unquoted text from #{token}"
+      raise ConfigBugOrBrokenError, "tried to get unquoted text from #{token}"
     end
   end
 
@@ -339,7 +341,7 @@ class Hocon::Impl::Tokens
     if token.is_a?(Value)
       token.value
     else
-      raise ConfigBugError, "tried to get value of non-value token #{token}"
+      raise ConfigBugOrBrokenError, "tried to get value of non-value token #{token}"
     end
   end
 

--- a/lib/hocon/impl/tokens.rb
+++ b/lib/hocon/impl/tokens.rb
@@ -80,6 +80,10 @@ class Hocon::Impl::Tokens
       @value = expression
     end
 
+    def optional?
+      @optional
+    end
+
     attr_reader :value
 
     def ==(other)
@@ -319,6 +323,22 @@ class Hocon::Impl::Tokens
 
   def self.substitution?(token)
     token.is_a?(Substitution)
+  end
+
+  def self.get_substitution_path_expression(token)
+    if token.is_a?(Substitution)
+      token.value
+    else
+      raise ConfigBugOrBrokenError, "tried to get substitution from #{token}"
+    end
+  end
+
+  def self.get_substitution_optional(token)
+    if token.is_a?(Substitution)
+      token.optional?
+    else
+      raise ConfigBugOrBrokenError, "tried to get substitution optionality from #{token}"
+    end
   end
 
   def self.unquoted_text?(token)

--- a/lib/hocon/impl/url.rb
+++ b/lib/hocon/impl/url.rb
@@ -13,6 +13,10 @@ require 'hocon/impl'
 # closely.
 class Hocon::Impl::Url
   class MalformedUrlError < StandardError
+    def initialize(msg, cause = nil)
+      super(msg)
+      @cause = cause
+    end
   end
 
   def initialize(url)
@@ -21,8 +25,8 @@ class Hocon::Impl::Url
       if !(@url.kind_of?(URI::HTTP))
         raise MalformedUrlError, "Unrecognized URL: '#{url}'"
       end
-    rescue URI::InvalidURIError
-      raise MalformedUrlError, "Unrecognized URL: '#{url}'"
+    rescue URI::InvalidURIError => e
+      raise MalformedUrlError.new("Unrecognized URL: '#{url}' (error: #{e})", e)
     end
   end
 end

--- a/lib/hocon/impl/url.rb
+++ b/lib/hocon/impl/url.rb
@@ -1,0 +1,28 @@
+# encoding: utf-8
+
+require 'uri'
+require 'hocon/impl'
+
+# There are several places in the Java codebase that
+# use Java's URL constructor, and rely on it to throw
+# a `MalformedURLException` if the URL isn't valid.
+#
+# Ruby doesn't really have a similar constructor /
+# validator, so this is a little shim to hopefully
+# make the ported code match up with the upstream more
+# closely.
+class Hocon::Impl::Url
+  class MalformedUrlError < StandardError
+  end
+
+  def initialize(url)
+    begin
+      @url = URI.parse(url)
+      if !(@url.kind_of?(URI::HTTP))
+        raise MalformedUrlError, "Unrecognized URL: '#{url}'"
+      end
+    rescue URI::InvalidURIError
+      raise MalformedUrlError, "Unrecognized URL: '#{url}'"
+    end
+  end
+end

--- a/spec/test_utils.rb
+++ b/spec/test_utils.rb
@@ -30,9 +30,7 @@ module TestUtils
       if e.is_a?(exception_type)
         thrown = e
       else
-        # puts "ERROR!: #{e}"
-        # puts e.backtrace
-        raise ArgumentError, "Expected exception #{exception_type} was not thrown, got #{e}"
+        raise ArgumentError, "Expected exception #{exception_type} was not thrown, got #{e}\n#{e.backtrace.join("\n")}"
       end
     end
     if thrown.nil?
@@ -151,14 +149,9 @@ module TestUtils
       ParseTest.from_s("${ #comment }"),
       ParseTest.from_s("[ // comment ]"),
       ParseTest.from_s("${ // comment }"),
-
-      # TODO: these are commented out because they require support for
-      #  `parse_include`, which we don't have yet.
-      #
-      # ParseTest.from_s("{ include \"bar\" : 10 }"), # include with a value after it
-      # ParseTest.from_s("{ include foo }"), # include with unquoted string
-      # ParseTest.from_s("{ include : { \"a\" : 1 } }"), # include used as unquoted key
-
+      ParseTest.from_s("{ include \"bar\" : 10 }"), # include with a value after it
+      ParseTest.from_s("{ include foo }"), # include with unquoted string
+      ParseTest.from_s("{ include : { \"a\" : 1 } }"), # include used as unquoted key
       ParseTest.from_s("a="), # no value
       ParseTest.from_s("a:"), # no value with colon
       ParseTest.from_s("a= "), # no value with whitespace after
@@ -173,11 +166,11 @@ module TestUtils
     rescue => e
       tokens =
           begin
-            "tokens: " + TestUtils.tokenize_as_list(s)
+            "tokens: " + TestUtils.tokenize_as_list(s).join("\n")
           rescue => tokenize_ex
-            "tokenizer failed: #{tokenize_ex}"
+            "tokenizer failed: #{tokenize_ex}\n#{tokenize_ex.backtrace.join("\n")}"
           end
-      raise ArgumentError, "#{parser_name} parser did wrong thing on '#{s}', #{tokens}; error: #{e}"
+      raise ArgumentError, "#{parser_name} parser did wrong thing on '#{s}', #{tokens}; error: #{e}\n#{e.backtrace.join("\n")}"
     end
   end
 

--- a/spec/test_utils.rb
+++ b/spec/test_utils.rb
@@ -116,18 +116,17 @@ module TestUtils
       ParseTest.from_s("[${]"), # unclosed substitution
       ParseTest.from_s("[$]"), # '$' by itself
       ParseTest.from_s("[$  ]"), # '$' by itself with spaces after
+      ParseTest.from_s("[${}]"), # empty substitution (no path)
+      ParseTest.from_s("[${?}]"), # no path with ? substitution
+      ParseTest.new(false, true, "[${ ?foo}]"), # space before ? not allowed
+      ParseTest.from_s(%q|{ "a" : [1,2], "b" : y${a}z }|), # trying to interpolate an array in a string
+      ParseTest.from_s(%q|{ "a" : { "c" : 2 }, "b" : y${a}z }|), # trying to interpolate an object in a string
 
-      # TODO: these are commented out because they need `ConfigReference`, which we
-      #  don't have yet.
-      #
-      # ParseTest.from_s("[${}]"), # empty substitution (no path)
-      # ParseTest.from_s("[${?}]"), # no path with ? substitution
-      # ParseTest.new(false, true, "[${ ?foo}]"), # space before ? not allowed
-      # ParseTest.from_s(%q|{ "a" : [1,2], "b" : y${a}z }|), # trying to interpolate an array in a string
-      # ParseTest.from_s(%q|{ "a" : { "c" : 2 }, "b" : y${a}z }|), # trying to interpolate an object in a string
-      # ParseTest.from_s(%q|{ "a" : ${a} }|), # simple cycle
-      # ParseTest.from_s(%q|[ { "a" : 2, "b" : ${${a}} } ]|), # nested substitution
-      #
+      # TODO: this test is commented out because our parser doesn't properly
+      #  detect the cycle.  Need to debug and fix, and then uncomment this test.
+      #ParseTest.from_s(%q|{ "a" : ${a} }|), # simple cycle
+
+      ParseTest.from_s(%q|[ { "a" : 2, "b" : ${${a}} } ]|), # nested substitution
       ParseTest.from_s("[ = ]"), # = is not a valid token in unquoted text
       ParseTest.from_s("[ + ]"),
       ParseTest.from_s("[ # ]"),

--- a/spec/test_utils.rb
+++ b/spec/test_utils.rb
@@ -121,11 +121,7 @@ module TestUtils
       ParseTest.new(false, true, "[${ ?foo}]"), # space before ? not allowed
       ParseTest.from_s(%q|{ "a" : [1,2], "b" : y${a}z }|), # trying to interpolate an array in a string
       ParseTest.from_s(%q|{ "a" : { "c" : 2 }, "b" : y${a}z }|), # trying to interpolate an object in a string
-
-      # TODO: this test is commented out because our parser doesn't properly
-      #  detect the cycle.  Need to debug and fix, and then uncomment this test.
-      #ParseTest.from_s(%q|{ "a" : ${a} }|), # simple cycle
-
+      ParseTest.from_s(%q|{ "a" : ${a} }|), # simple cycle
       ParseTest.from_s(%q|[ { "a" : 2, "b" : ${${a}} } ]|), # nested substitution
       ParseTest.from_s("[ = ]"), # = is not a valid token in unquoted text
       ParseTest.from_s("[ + ]"),


### PR DESCRIPTION
This commit re-enables some disabled config parser tests that
had been failing due to missing functionality around HOCON's
`include` capabilities.  It also includes a minimal port
of all of the `include` functionality that was required
to get the tests passing.