### PR TITLE
(MAINT) flesh out simple config object

### DIFF
--- a/lib/hocon/impl/abstract_config_object.rb
+++ b/lib/hocon/impl/abstract_config_object.rb
@@ -29,12 +29,112 @@ class Hocon::Impl::AbstractConfigObject < Hocon::Impl::AbstractConfigValue
     self
   end
 
+  def with_only_key(key)
+    raise ConfigBugOrBrokenError, "subclasses of AbstractConfigObject should override `with_only_key`"
+  end
+
+  def without_key(key)
+    raise ConfigBugOrBrokenError, "subclasses of AbstractConfigObject should override `without_key`"
+  end
+
+  def with_value(key, value)
+    raise ConfigBugOrBrokenError, "subclasses of AbstractConfigObject should override `with_value`"
+  end
+
+  def with_only_path_or_nil(path)
+    raise ConfigBugOrBrokenError, "subclasses of AbstractConfigObject should override `with_only_path_or_nil`"
+  end
+
+  def with_only_path(path)
+    raise ConfigBugOrBrokenError, "subclasses of AbstractConfigObject should override `with_only_path`"
+  end
+
+  def without_path(path)
+    raise ConfigBugOrBrokenError, "subclasses of AbstractConfigObject should override `without_path`"
+  end
+
+  def with_path_value(path, value)
+    raise ConfigBugOrBrokenError, "subclasses of AbstractConfigObject should override `with_path_value`"
+  end
+
+  # This looks up the key with no transformation or type conversion of any
+  # kind, and returns null if the key is not present. The object must be
+  # resolved along the nodes needed to get the key or
+  # ConfigNotResolvedError will be thrown.
+  #
+  # @param key
+  # @return the unmodified raw value or null
+  def peek_assuming_resolved(key, original_path)
+    begin
+      attempt_peek_with_partial_resolve(key)
+    rescue ConfigNotResolvedError => e
+      raise Hocon::Impl::ConfigImpl.improve_not_resolved(original_path, e)
+    end
+  end
+
+  # Look up the key on an only-partially-resolved object, with no
+  # transformation or type conversion of any kind; if 'this' is not resolved
+  # then try to look up the key anyway if possible.
+  #
+  # @param key
+  #            key to look up
+  # @return the value of the key, or null if known not to exist
+  # @throws ConfigNotResolvedError
+  #             if can't figure out key's value (or existence) without more
+  #             resolving
+  def attempt_peek_with_partial_resolve(key)
+    raise ConfigBugOrBrokenError, "subclasses of AbstractConfigObject should override `attempt_peek_with_partial_resolve`"
+  end
+
+  # Looks up the path with no transformation or type conversion. Returns null
+  # if the path is not found; throws ConfigException.NotResolved if we need
+  # to go through an unresolved node to look up the path.
+  def peek_path(path)
+    peek_path_from_obj(self, path)
+  end
+
+  def peek_path_from_obj(obj, path)
+    begin
+      # we'll fail if anything along the path can't be looked at without resolving
+      path_next = path.remainder
+      v = obj.attempt_peek_with_partial_resolve(path.first)
+
+      if path_next.nil?
+        v
+      else
+        if v.is_a?(AbstractConfigObject)
+          peek_path_from_obj(v, path_next)
+        else
+          nil
+        end
+      end
+    rescue ConfigNotResolvedError => e
+      raise Hocon::Impl::ConfigImpl.improve_not_resolved(path, e)
+    end
+  end
+
   def value_type
     Hocon::ConfigValueType::OBJECT
   end
 
+  def new_copy_with_status(status, origin)
+    raise ConfigBugOrBrokenError, "subclasses of AbstractConfigObject should override `new_copy_with_status`"
+  end
+
   def new_copy(origin)
     new_copy_with_status(resolve_status, origin)
+  end
+
+  def construct_delayed_merge(origin, stack)
+    Hocon::Impl::ConfigDelayedMergeObject.new(origin, stack)
+  end
+
+  def merged_with_object(fallback)
+    raise ConfigBugOrBrokenError, "subclasses of AbstractConfigObject should override `merged_with_object`"
+  end
+
+  def with_fallback(mergeable)
+    super(mergeable)
   end
 
   def merge_origins(stack)
@@ -69,51 +169,47 @@ class Hocon::Impl::AbstractConfigObject < Hocon::Impl::AbstractConfigValue
     Hocon::Impl::SimpleConfigOrigin.merge_origins(origins)
   end
 
-  def peek_assuming_resolved(key, original_path)
-    begin
-      attempt_peek_with_partial_resolve(key)
-    rescue ConfigNotResolvedError => e
-      raise Hocon::Impl::ConfigImpl.improve_not_resolved(original_path, e)
-    end
-  end
-
-  def peek_path(path)
-    begin
-      return peek_path_impl(self, path, nil)
-    rescue ConfigNotResolvedError => e
-      raise ConfigBugOrBrokenError.new("NotPossibleToResolve happened though we had no ResolveContext in peek_path", nil)
-    end
-  end
-
   def resolve_substitutions(context, source)
-    raise "'resolve_substitutions' needs to be overridden by sub-class, this is abstract in the Java version"
+    raise ConfigBugOrBrokenError, "subclasses of AbstractConfigObject should override `resolve_substituions`"
   end
 
-  def peek_path_impl(me, path, context)
-    begin
-      if not context.nil?
-        partially_resolved = context.restrict(path).resolve(me)
-        if partially_resolved.is_a?(self.class)
-          return peek_path_impl(partially_resolved, path, nil)
-        else
-          raise ConfigBugOrBrokenError.new(
-              "resolved object to non-object #{me} to #{partially_resolved}", nil)
-        end
-      else
-        remainder = path.remainder
-        v = me.attempt_peek_with_partial_resolve(path.first)
-        if remainder.nil?
-          return v
-        else
-          if v.is_a?(self.class)
-            return peek_path_impl(v, remainder, nil)
-          else
-            return nil
-          end
-        end
-      end
-    rescue ConfigNotResolvedError => e
-      raise Hocon::Impl::ConfigImpl.improve_not_resolved(path, e)
-    end
+  def relativized(path)
+    raise ConfigBugOrBrokenError, "subclasses of AbstractConfigObject should override `relativized`"
+  end
+
+  def [](key)
+    raise ConfigBugOrBrokenError, "subclasses of AbstractConfigObject should override `[]`"
+  end
+
+  def render_value_to_sb(sb, indent, at_root, options)
+    raise ConfigBugOrBrokenError, "subclasses of AbstractConfigObject should override `render_value_to_sb`"
+  end
+
+  def we_are_immutable(method)
+    ConfigBugOrBrokenError.new("ConfigObject is immutable, you can't call Map.#{method}")
+  end
+
+  def clear
+    raise we_are_immutable("clear")
+  end
+
+  def []=(key, value)
+    raise we_are_immutable("[]=")
+  end
+
+  def putAll(map)
+    raise we_are_immutable("putAll")
+  end
+
+  def remove(key)
+    raise we_are_immutable("remove")
+  end
+
+  def delete(key)
+    raise we_are_immutable("delete")
+  end
+
+  def with_origin(origin)
+    super(origin)
   end
 end

--- a/lib/hocon/impl/abstract_config_value.rb
+++ b/lib/hocon/impl/abstract_config_value.rb
@@ -43,6 +43,18 @@ class Hocon::Impl::AbstractConfigValue
     Hocon::Impl::ResolveStatus::RESOLVED
   end
 
+  class NoExceptionsModifier
+    def modify_child_may_throw(key_or_nil, v)
+      begin
+        modify_child(key_or_nil, v)
+      rescue Hocon::ConfigError => e
+        raise e
+      rescue => e
+        raise ConfigBugOrBrokenError("Unexpected exception", e)
+      end
+    end
+  end
+
   # this is virtualized rather than a field because only some subclasses
   # really need to store the boolean, and they may be able to pack it
   # with another boolean to save space.

--- a/lib/hocon/impl/abstract_config_value.rb
+++ b/lib/hocon/impl/abstract_config_value.rb
@@ -7,7 +7,6 @@ require 'hocon/config_object'
 require 'hocon/impl/resolve_status'
 require 'hocon/impl/resolve_result'
 require 'hocon/impl/unmergeable'
-require 'hocon/impl/abstract_config_object'
 require 'hocon/impl/config_impl_util'
 require 'hocon/config_error'
 
@@ -19,28 +18,98 @@ require 'hocon/config_error'
 class Hocon::Impl::AbstractConfigValue
   ConfigImplUtil = Hocon::Impl::ConfigImplUtil
   ConfigBugOrBrokenError = Hocon::ConfigError::ConfigBugOrBrokenError
-
-  attr_reader :origin
+  ResolveStatus = Hocon::Impl::ResolveStatus
 
   def initialize(origin)
     @origin = origin
   end
 
+  attr_reader :origin
+
+  # This exception means that a value is inherently not resolveable, at the
+  # moment the only known cause is a cycle of substitutions. This is a
+  # checked exception since it's internal to the library and we want to be
+  # sure we handle it before passing it out to public API. This is only
+  # supposed to be thrown by the target of a cyclic reference and it's
+  # supposed to be caught by the ConfigReference looking up that reference,
+  # so it should be impossible for an outermost resolve() to throw this.
+  #
+  # Contrast with ConfigException.NotResolved which just means nobody called
+  # resolve().
   class NotPossibleToResolve < Exception
-    attr_reader :trace_string
     def initialize(context)
       super("was not possible to resolve")
       @trace_string = context.trace_string
     end
+
+    attr_reader :trace_string
   end
 
+  # Called only by ResolveContext.resolve
+  #
+  # @param context
+  #            state of the current resolve
+  # @param source
+  #            where to look up values
+  # @return a new value if there were changes, or this if no changes
   def resolve_substitutions(context, source)
     Hocon::Impl::ResolveResult.make(context, self)
   end
 
-
   def resolve_status
     Hocon::Impl::ResolveStatus::RESOLVED
+  end
+
+  def self.replace_child_in_list(list, child, replacement)
+    i = 0
+    while (i < list.size) && (! list[i].equal?(child))
+      i += 1
+    end
+    if (i == list.size)
+      raise ConfigBugOrBrokenError, "tried to replace #{child} which is not in #{list}"
+    end
+
+    new_stack = list.clone
+    if ! replacement.nil?
+      new_stack[i] = replacement
+    else
+      new_stack.delete(i)
+    end
+
+    if new_stack.empty?
+      nil
+    else
+      new_stack
+    end
+  end
+
+  def self.has_descendant_in_list(list, descendant)
+    list.each do |v|
+      if v.equal?(descendant)
+        return true
+      end
+    end
+    # now the expensive traversal
+    list.each do |v|
+      if v.is_a?(Hocon::Impl::Container) && v.has_descendant(descendant)
+        return true
+      end
+    end
+    false
+  end
+
+  # This is used when including one file in another; the included file is
+  # relativized to the path it's included into in the parent file. The point
+  # is that if you include a file at foo.bar in the parent, and the included
+  # file as a substitution ${a.b.c}, the included substitution now needs to
+  # be ${foo.bar.a.b.c} because we resolve substitutions globally only after
+  # parsing everything.
+  #
+  # @param prefix
+  # @return value relativized to the given path or the same value if nothing
+  #         to do
+  def relativized(prefix)
+    self
   end
 
   class NoExceptionsModifier
@@ -55,6 +124,14 @@ class Hocon::Impl::AbstractConfigValue
     end
   end
 
+  def to_fallback_value
+    self
+  end
+
+  def new_copy(origin)
+    raise ConfigBugOrBrokenError, "subclasses of AbstractConfigValue should provide their own implementation of `new_copy`"
+  end
+
   # this is virtualized rather than a field because only some subclasses
   # really need to store the boolean, and they may be able to pack it
   # with another boolean to save space.
@@ -64,12 +141,92 @@ class Hocon::Impl::AbstractConfigValue
     resolve_status == Hocon::Impl::ResolveStatus::RESOLVED
   end
 
+  def with_fallbacks_ignored
+    if ignores_fallbacks?
+      self
+    else
+      raise ConfigBugOrBrokenError, "value class doesn't implement forced fallback-ignoring #{self}"
+    end
+  end
+
   # the withFallback() implementation is supposed to avoid calling
   # mergedWith* if we're ignoring fallbacks.
   def require_not_ignoring_fallbacks
     if ignores_fallbacks?
       raise ConfigBugOrBrokenError, "method should not have been called with ignoresFallbacks=true #{self.class.name}"
     end
+  end
+
+  def construct_delayed_merge(origin, stack)
+    # TODO: this might not work because ConfigDelayedMerge inherits
+    # from this class, so we can't `require` it from this file
+    Hocon::Impl::ConfigDelayedMerge.new(origin, stack)
+  end
+
+  def merged_stack_with_the_unmergeable(stack, fallback)
+    require_not_ignoring_fallbacks
+
+    # if we turn out to be an object, and the fallback also does,
+    # then a merge may be required; delay until we resolve.
+    new_stack = stack.clone
+    new_stack.concat(fallback.unmerged_values)
+    # TODO: this might not work because AbstractConfigObject inherits
+    # from this class, so we can't `require` it from this file
+    construct_delayed_merge(Hocon::Impl::AbstractConfigObject.merge_origins(new_stack), new_stack)
+  end
+
+  def delay_merge(stack, fallback)
+    # if we turn out to be an object, and the fallback also does,
+    # then a merge may be required.
+    # if we contain a substitution, resolving it may need to look
+    # back to the fallback
+    new_stack = stack.clone
+    new_stack << fallback
+    # TODO: this might not work because AbstractConfigObject inherits
+    # from this class, so we can't `require` it from this file
+    construct_delayed_merge(Hocon::Impl::AbstractConfigObject.merge_origins(new_stack), new_stack)
+  end
+
+  def merged_stack_with_object(stack, fallback)
+    require_not_ignoring_fallbacks
+
+    # TODO: this might not work because AbstractConfigObject inherits
+    # from this class, so we can't `require` it from this file
+    if self.is_a?(Hocon::Impl::AbstractConfigObject)
+      raise ConfigBugOrBrokenError, "Objects must reimplement merged_with_object"
+    end
+
+    merged_stack_with_non_object(stack, fallback)
+  end
+
+  def merged_stack_with_non_object(stack, fallback)
+    require_not_ignoring_fallbacks
+
+    if resolve_status == ResolveStatus::RESOLVED
+      # falling back to a non-object doesn't merge anything, and also
+      # prohibits merging any objects that we fall back to later.
+      # so we have to switch to ignoresFallbacks mode.
+      with_fallbacks_ignored
+    else
+      # if unresolved we may have to look back to fallbacks as part of
+      # the resolution process, so always delay
+      delay_merge(stack, fallback)
+    end
+  end
+
+  def merged_with_the_unmergeable(fallback)
+    require_not_ignoring_fallbacks
+    merged_stack_with_the_unmergeable([self], fallback)
+  end
+
+  def merged_with_object(fallback)
+    require_not_ignoring_fallbacks
+    merged_stack_with_object([self], fallback)
+  end
+
+  def merged_with_non_object(fallback)
+    require_not_ignoring_fallbacks
+    merged_stack_with_non_object([self], fallback)
   end
 
   def with_origin(origin)
@@ -87,6 +244,8 @@ class Hocon::Impl::AbstractConfigValue
       other = mergeable.to_fallback_value
       if other.is_a?(Hocon::Impl::Unmergeable)
         merged_with_the_unmergeable(other)
+        # TODO: this probably isn't going to work because AbstractConfigObject inherits
+        # from this class, so we can't `require` it from this file
       elsif other.is_a?(Hocon::Impl::AbstractConfigObject)
         merged_with_object(other)
       else
@@ -180,6 +339,15 @@ class Hocon::Impl::AbstractConfigValue
     # sb.pos at various points in the code as a means to remove characters from
     # the end of the StringIO
     sb.string[0, sb.pos]
+  end
+
+  # toString() is a debugging-oriented string but this is defined
+  # to create a string that would parse back to the value in JSON.
+  # It only works for primitive values (that would be a single
+  # which are auto-converted to strings when concatenating with
+  # other strings or by the DefaultTransformer.
+  def transform_to_string
+    nil
   end
 
   def at_key(origin, key)

--- a/lib/hocon/impl/simple_config_object.rb
+++ b/lib/hocon/impl/simple_config_object.rb
@@ -337,6 +337,7 @@ class Hocon::Impl::SimpleConfigObject < Hocon::Impl::AbstractConfigObject
       else
         # no restrictToChild, resolve everything
         result = @context.unrestricted.restrict(@original_restrict)
+        @context = result.context.unrestricted.restrict(@original_restrict)
         result.value
       end
     end

--- a/lib/hocon/impl/simple_config_object.rb
+++ b/lib/hocon/impl/simple_config_object.rb
@@ -358,7 +358,7 @@ class Hocon::Impl::SimpleConfigObject < Hocon::Impl::AbstractConfigObject
 
     rescue NotPossibleToResolve => e
       raise e
-    rescue RuntimeError => e
+    rescue Hocon::ConfigError => e
       raise e
     rescue Exception => e
       raise ConfigBugOrBrokenError.new("unexpected exception", e)

--- a/lib/hocon/impl/simple_config_object.rb
+++ b/lib/hocon/impl/simple_config_object.rb
@@ -336,7 +336,7 @@ class Hocon::Impl::SimpleConfigObject < Hocon::Impl::AbstractConfigObject
         end
       else
         # no restrictToChild, resolve everything
-        result = @context.unrestricted.restrict(@original_restrict)
+        result = @context.unrestricted.resolve(v, @source)
         @context = result.context.unrestricted.restrict(@original_restrict)
         result.value
       end

--- a/lib/hocon/impl/simple_config_object.rb
+++ b/lib/hocon/impl/simple_config_object.rb
@@ -334,11 +334,11 @@ class Hocon::Impl::SimpleConfigObject < Hocon::Impl::AbstractConfigObject
           # not in the restrictToChild path
           v
         end
+      else
+        # no restrictToChild, resolve everything
+        result = @context.unrestricted.restrict(@original_restrict)
+        result.value
       end
-    else
-      # no restrictToChild, resolve everything
-      result = @context.unrestricted.restrict(@original_restrict)
-      result.value
     end
   end
 

--- a/lib/hocon/impl/simple_config_object.rb
+++ b/lib/hocon/impl/simple_config_object.rb
@@ -5,6 +5,7 @@ require 'hocon/impl/simple_config_origin'
 require 'hocon/impl/abstract_config_object'
 require 'hocon/impl/resolve_status'
 require 'hocon/impl/resolve_result'
+require 'hocon/impl/path'
 require 'hocon/config_error'
 require 'set'
 require 'forwardable'
@@ -17,16 +18,12 @@ class Hocon::Impl::SimpleConfigObject < Hocon::Impl::AbstractConfigObject
   ResolveStatus = Hocon::Impl::ResolveStatus
   ResolveResult = Hocon::Impl::ResolveResult
   SimpleConfigOrigin = Hocon::Impl::SimpleConfigOrigin
+  Path = Hocon::Impl::Path
 
-  def self.empty_missing(base_origin)
-    self.new(
-        Hocon::Impl::SimpleConfigOrigin.new_simple("#{base_origin.description} (not found)"),
-        {})
-  end
 
   def initialize(origin, value,
-                  status = Hocon::Impl::ResolveStatus.from_values(value.values),
-                  ignores_fallbacks = false)
+                 status = Hocon::Impl::ResolveStatus.from_values(value.values),
+                 ignores_fallbacks = false)
     super(origin)
     if value.nil?
       raise ConfigBugOrBrokenError, "creating config object with null map"
@@ -46,9 +43,161 @@ class Hocon::Impl::SimpleConfigObject < Hocon::Impl::AbstractConfigObject
   def_delegators :@value, :[], :has_key?, :has_value?, :empty?, :size, :keys, :values, :each, :map
 
 
+  def with_only_key(key)
+    with_only_path(Path.new_key(key))
+  end
+
+  def without_key(key)
+    without_path(Path.new_key(key))
+  end
+
+  # gets the object with only the path if the path
+  # exists, otherwise null if it doesn't. this ensures
+  # that if we have { a : { b : 42 } } and do
+  # withOnlyPath("a.b.c") that we don't keep an empty
+  # "a" object.
+  def with_only_path_or_nil(path)
+    key = path.first
+    path_next = path.remainder
+    v = value[key]
+
+    if ! path_next.nil?
+      if (!v.nil?) && (v.is_a?(Hocon::Impl::AbstractConfigObject))
+        v = v.with_only_path_or_nil(path_next)
+      else
+        # if the path has more elements but we don't have an object,
+        # then the rest of the path does not exist.
+        v = nil
+      end
+    end
+
+    if v.nil?
+      nil
+    else
+      self.class.new(origin, {key => v}, v.resolve_status, @ignores_fallbacks)
+    end
+  end
+
+  def with_only_path(path)
+    o = with_only_path_or_nil(path)
+    if o.nil?
+      self.class.new(origin, {}, ResolveStatus::RESOLVED, @ignores_fallbacks)
+    else
+      o
+    end
+  end
+
+  def without_path(path)
+    key = path.first
+    remainder = path.remainder
+    v = @value[key]
+
+    if (not v.nil?) && (not remainder.nil?) && v.is_a?(Hocon::Impl::AbstractConfigObject)
+      v = v.without_path(remainder)
+      updated = @value.clone
+      updated[key] = v
+      Hocon::Impl::SimpleConfigObject.new(origin,
+                                          updated,
+                                          ResolveStatus.from_values(updated.values), @ignores_fallbacks)
+    elsif (not remainder.nil?) || v.nil?
+      return self
+    else
+      smaller = Hash.new
+      @value.each do |old_key, old_value|
+        unless old_key == key
+          smaller[old_key] = old_value
+        end
+      end
+      Hocon::Impl::SimpleConfigObject.new(origin,
+                                          smaller,
+                                          ResolveStatus.from_values(smaller.values), @ignores_fallbacks)
+    end
+  end
+
+  def with_value(path, v)
+    key = path.first
+    remainder = path.remainder
+
+    if remainder.nil?
+      with_key_value(key, v)
+    else
+      child = @value[key]
+      if (not child.nil?) && child.is_a?(Hocon::Impl::AbstractConfigObject)
+        return with_key_value(key, child.with_value(remainder, v))
+      else
+        subtree = v.at_path(
+            SimpleConfigOrigin.new_simple("with_value(#{remainder.render})"), remainder)
+        with_key_value(key, subtree.root)
+      end
+    end
+  end
+
+  def with_key_value(key, v)
+    if v.nil?
+      raise ConfigBugOrBrokenError.new("Trying to store null ConfigValue in a ConfigObject")
+    end
+
+    new_map = Hash.new
+    if @value.empty?
+      new_map[key] = v
+    else
+      new_map = @value.clone
+      new_map[key] = v
+    end
+    self.class.new(origin, new_map, ResolveStatus.from_values(new_map.values), @ignores_fallbacks)
+  end
+
+  def attempt_peek_with_partial_resolve(key)
+    @value[key]
+  end
+
   def new_copy_with_status(new_status, new_origin, new_ignores_fallbacks = nil)
-    Hocon::Impl::SimpleConfigObject.new(new_origin,
-              @value, new_status, new_ignores_fallbacks)
+    self.class.new(new_origin, @value, new_status, new_ignores_fallbacks)
+  end
+
+  def with_fallbacks_ignored()
+    if @ignores_fallbacks
+      self
+    else
+      new_copy_with_status(resolve_status, origin, true)
+    end
+  end
+
+  def resolve_status
+    ResolveStatus.from_boolean(@resolved)
+  end
+
+  def replace_child(child, replacement)
+    new_children = value.clone
+    new_children.each do |k, v|
+      if v == child
+        if ! replacement.nil?
+          new_children[k] = replacement
+        else
+          new_children.delete(k)
+        end
+
+        self.class.new(origin, new_children, ResolveStatus.from_values(new_children.values),
+                       @ignores_fallbacks)
+      end
+    end
+    raise ConfigBugOrBroken, "SimpleConfigObject.replaceChild did not find #{child} in #{self}"
+  end
+
+  def has_descendant(descendant)
+    value.values.each do |child|
+      if child.equal?(descendant)
+        return true
+      end
+    end
+    # now do the expensive search
+    value.values.each do |child|
+      if child.is_a?(Hocon::Impl::Container) && child.has_descendant(descendant)
+        return true
+      end
+    end
+
+    false
   end
 
   def ignores_fallbacks?
@@ -98,12 +247,158 @@ class Hocon::Impl::SimpleConfigObject < Hocon::Impl::AbstractConfigObject
 
     if changed
       Hocon::Impl::SimpleConfigObject.new(merge_origins([self, fallback]),
-                             merged, new_resolve_status,
-                             new_ignores_fallbacks)
+                                          merged, new_resolve_status,
+                                          new_ignores_fallbacks)
     elsif (new_resolve_status != resolve_status) || (new_ignores_fallbacks != ignores_fallbacks?)
       newCopy(new_resolve_status, origin, new_ignores_fallbacks)
     else
       self
+    end
+  end
+
+  def modify(modifier)
+    begin
+      modify_may_throw(modifier)
+    rescue Hocon::ConfigError => e
+      raise e
+    rescue => e
+      raise ConfigBugOrBrokenError.new("unexpected exception", e)
+    end
+  end
+
+  def modify_may_throw(modifier)
+    changes = nil
+    keys.each do |k|
+      v = value[k]
+      # "modified" may be null, which means remove the child;
+      # to do that we put null in the "changes" map.
+      modified = modifier.modify_child_may_throw(k, v)
+      if ! modified.equal?(v)
+        if changes.nil?
+          changes = {}
+        end
+        changes[k] = modified
+      end
+    end
+    if changes.nil?
+      self
+    else
+      modified = {}
+      saw_unresolved = false
+      keys.each do |k|
+        if changes.has_key?(k)
+          new_value = changes[k]
+          if ! new_value.nil?
+            modified[k] = new_value
+            if new_value.resolve_status == ResolveStatus::UNRESOLVED
+              saw_unresolved = true
+            end
+          else
+            # remove this child; don't put it in the new map
+          end
+        else
+          new_value = value[k]
+          modified[k] = new_value
+          if new_value.resolve_status == ResolveStatus::UNRESOLVED
+            saw_unresolved = true
+          end
+        end
+      end
+      self.class.new(origin, modified,
+                     saw_unresolved ? ResolveStatus::UNRESOLVED : ResolveStatus::RESOLVED,
+                     @ignores_fallbacks)
+    end
+  end
+
+
+  class ResolveModifier
+    def initialize(context, source)
+      @context = context
+      @source = source
+      @original_restrict = context.restrict_to_child
+    end
+
+    def modify_child_may_throw(key, v)
+      if @context.restricted_to_child?
+        if key == @context.restrict_to_child.first
+          remainder = @context.restrict_to_child.remainder
+          if remainder.nil?
+            result = @context.restrict(remainder).resolve(v, @source)
+            @context = result.context.unrestricted.restrict(@original_restrict)
+            result.value
+          else
+            # we don't want to resolve the leaf child
+            v
+          end
+        else
+          # not in the restrictToChild path
+          v
+        end
+      end
+    else
+      # no restrictToChild, resolve everything
+      result = @context.unrestricted.restrict(@original_restrict)
+      result.value
+    end
+  end
+
+  def resolve_substitutions(context, source)
+    if resolve_status == ResolveStatus::RESOLVED
+      return ResolveResult.make(context, self)
+    end
+
+    source_with_parent = source.push_parent(self)
+
+    begin
+      modifier = ResolveModifier.new(context, source_with_parent)
+
+      value = modify_may_throw(modifier)
+      ResolveResult.make(modifier.context, value)
+
+    rescue NotPossibleToResolve => e
+      raise e
+    rescue RuntimeError => e
+      raise e
+    rescue Exception => e
+      raise ConfigBugOrBrokenError.new("unexpected exception", e)
+    end
+  end
+
+  def relativized(prefix)
+    modifier = Class.new do
+      extend Hocon::Impl::AbstractConfigValue::NoExceptionsModifier
+
+      def modify_child(key, v)
+        v.relativized(prefix)
+      end
+    end
+
+    modify(modifier.new)
+  end
+
+  class RenderComparator
+    def self.all_digits?(s)
+      s =~ /^\d+$/
+    end
+
+    # This is supposed to sort numbers before strings,
+    # and sort the numbers numerically. The point is
+    # to make objects which are really list-like
+    # (numeric indices) appear in order.
+    def self.sort(arr)
+      arr.sort do |a, b|
+        a_digits = all_digits?(a)
+        b_digits = all_digits?(b)
+        if a_digits && b_digits
+          Integer(a) <=> Integer(b)
+        elsif a_digits
+          -1
+        elsif b_digits
+          1
+        else
+          a <=> b
+        end
+      end
     end
   end
 
@@ -114,18 +409,19 @@ class Hocon::Impl::SimpleConfigObject < Hocon::Impl::AbstractConfigObject
       outer_braces = options.json? || !at_root
 
       inner_indent =
-        if outer_braces
-          sb << "{"
-          if options.formatted?
-            sb << "\n"
+          if outer_braces
+            sb << "{"
+            if options.formatted?
+              sb << "\n"
+            end
+            indent_size + 1
+          else
+            indent_size
           end
-          indent_size + 1
-        else
-          indent_size
-        end
 
       separator_count = 0
-      key_set.each do |k|
+      sorted_keys = RenderComparator.sort(keys)
+      sorted_keys.each do |k|
         v = @value[k]
 
         if options.origin_comments?
@@ -182,9 +478,37 @@ class Hocon::Impl::SimpleConfigObject < Hocon::Impl::AbstractConfigObject
     end
   end
 
+  def self.map_equals(a, b)
+    if a == b
+      return true
+    end
 
-  def key_set
-    Set.new(@value.keys)
+    # Hashes aren't ordered in ruby, so sort first
+    if not a.keys.sort == b.keys.sort
+      return false
+    end
+
+    a.keys.each do |key|
+      if a[key] != b[key]
+        return false
+      end
+    end
+
+    true
+  end
+
+  def self.map_hash(m)
+    # the keys have to be sorted, otherwise we could be equal
+    # to another map but have a different hashcode.
+    keys = m.keys.sort
+
+    value_hash = 0
+
+    keys.each do |key|
+      value_hash += m[key].hash
+    end
+
+    41 * (41 + keys.hash) + value_hash
   end
 
   def can_equal(other)
@@ -207,98 +531,16 @@ class Hocon::Impl::SimpleConfigObject < Hocon::Impl::AbstractConfigObject
     self.class.map_hash(@value)
   end
 
-  def empty?
-    @value.empty?
+  def contains_key?(key)
+    @value.has_key?(key)
   end
 
-  def attempt_peek_with_partial_resolve(key)
-    @value[key]
+  def key_set
+    Set.new(@value.keys)
   end
 
-  def without_path(path)
-    key = path.first
-    remainder = path.remainder
-    v = @value[key]
-
-    if (not v.nil?) && (not remainder.nil?) && v.is_a?(Hocon::Impl::AbstractConfigObject)
-      v = v.without_path(remainder)
-      updated = @value.clone
-      updated[key] = v
-      Hocon::Impl::SimpleConfigObject.new(origin,
-                                          updated,
-                                          ResolveStatus.from_values(updated.values), @ignores_fallbacks)
-    elsif (not remainder.nil?) || v.nil?
-      return self
-    else
-      smaller = Hash.new
-      @value.each do |old_key, old_value|
-        unless old_key == key
-          smaller[old_key] = old_value
-        end
-      end
-      Hocon::Impl::SimpleConfigObject.new(origin,
-                                          smaller,
-                                          ResolveStatus.from_values(smaller.values), @ignores_fallbacks)
-    end
-  end
-
-  def with_value(path, v)
-    key = path.first
-    remainder = path.remainder
-
-    if remainder.nil?
-      with_value_impl(key, v)
-    else
-      child = @value[key]
-      if (not child.nil?) && child.is_a?(Hocon::Impl::AbstractConfigObject)
-        return with_value_impl(key, child.with_value(remainder, v))
-      else
-        subtree = v.at_path(
-            SimpleConfigOrigin.new_simple("with_value(#{remainder.render})"), remainder)
-        with_value_impl(key, subtree.root)
-      end
-    end
-  end
-
-  def with_value_impl(key, v)
-    if v.nil?
-      raise ConfigBugOrBrokenError.new("Trying to store null ConfigValue in a ConfigObject")
-    end
-
-    new_map = Hash.new
-    if @value.empty?
-      new_map[key] = v
-    else
-      new_map = @value.clone
-      new_map[key] = v
-    end
-    self.class.new(origin, new_map, ResolveStatus.from_values(new_map.values), @ignores_fallbacks)
-  end
-
-  def resolve_status
-    ResolveStatus.from_boolean(@resolved)
-  end
-
-  def resolve_substitutions(context, source)
-    if resolve_status == ResolveStatus::RESOLVED
-      return ResolveResult.make(context, self)
-    end
-
-    source_with_parent = source.push_parent(self)
-
-    begin
-      modifier = ResolveModifier.new(context, source_with_parent)
-
-      value = modify_may_throw(modifier)
-      ResolveResult.make(modifier.context, value)
-
-    rescue NotPossibleToResolve => e
-      raise e
-    rescue RuntimeError => e
-      raise e
-    rescue Exception => e
-      raise ConfigBugOrBrokenError.new("unexpected exception", e)
-    end
+  def contains_value?(v)
+    @value.has_value?(v)
   end
 
   def self.empty(origin = nil)
@@ -309,38 +551,9 @@ class Hocon::Impl::SimpleConfigObject < Hocon::Impl::AbstractConfigObject
     end
   end
 
-  private
-
-  def self.map_hash(m)
-    # the keys have to be sorted, otherwise we could be equal
-    # to another map but have a different hashcode.
-    keys = m.keys.sort
-
-    value_hash = 0
-
-    keys.each do |key|
-      value_hash += m[key].hash
-    end
-
-    41 * (41 + keys.hash) + value_hash
-  end
-
-  def self.map_equals(a, b)
-    if a == b
-      return true
-    end
-
-    # Hashes aren't ordered in ruby, so sort first
-    if not a.keys.sort == b.keys.sort
-      return false
-    end
-
-    a.keys.each do |key|
-      if a[key] != b[key]
-        return false
-      end
-    end
-
-    true
+  def self.empty_missing(base_origin)
+    self.new(
+        Hocon::Impl::SimpleConfigOrigin.new_simple("#{base_origin.description} (not found)"),
+        {})
   end
 end

--- a/spec/unit/typesafe/config/config_value_spec.rb
+++ b/spec/unit/typesafe/config/config_value_spec.rb
@@ -4,6 +4,7 @@ require 'test_utils'
 
 require 'hocon/impl/config_delayed_merge'
 require 'hocon/impl/config_delayed_merge_object'
+require 'hocon/config_error'
 
 
 
@@ -16,6 +17,7 @@ ConfigConcatenation = Hocon::Impl::ConfigConcatenation
 ConfigDelayedMerge = Hocon::Impl::ConfigDelayedMerge
 ConfigDelayedMergeObject = Hocon::Impl::ConfigDelayedMergeObject
 ConfigNotResolvedError = Hocon::ConfigError::ConfigNotResolvedError
+ConfigBugOrBrokenError = Hocon::ConfigError::ConfigBugOrBrokenError
 AbstractConfigObject = Hocon::Impl::AbstractConfigObject
 
 describe "SimpleConfigOrigin equality" do
@@ -425,8 +427,8 @@ describe "ConfigObject" do
     keys = [:a, :b, :c]
     expect(keys).to eq(m.keys)
 
-    expect { m["hello"] = TestUtils.int_value(41) }.to raise_error(NoMethodError)
-    expect { m.delete(:a) }.to raise_error(NoMethodError)
+    expect { m["hello"] = TestUtils.int_value(41) }.to raise_error(ConfigBugOrBrokenError)
+    expect { m.delete(:a) }.to raise_error(ConfigBugOrBrokenError)
   end
 end
 


### PR DESCRIPTION
This commit cleans up the order of the code in `SimpleConfigObject` to more closely mirror that of the upstream, and also ports over a bunch of stuff that hadn't been ported yet.