### PR TITLE
(TK-162) enable concatenation test cases + fixes

### DIFF
--- a/lib/hocon/impl/abstract_config_value.rb
+++ b/lib/hocon/impl/abstract_config_value.rb
@@ -289,6 +289,10 @@ module Hocon::Impl::AbstractConfigValue
     "#{self.class.name.split('::').last}(#{sb.string})"
   end
 
+  def inspect
+    to_s
+  end
+
   def self.indent(sb, indent_size, options)
     if options.formatted?
       remaining = indent_size

--- a/lib/hocon/impl/config_concatenation.rb
+++ b/lib/hocon/impl/config_concatenation.rb
@@ -96,6 +96,10 @@ class Hocon::Impl::ConfigConcatenation
       joined = right.with_fallback(left)
     elsif (left.is_a?(SimpleConfigList)) && (right.is_a?(SimpleConfigList))
       joined = left.concatenate(right)
+    elsif (left.is_a?(SimpleConfigList) || left.is_a?(ConfigObject)) &&
+           is_ignored_whitespace(right)
+      joined = left
+      # it should be impossible that left is whitespace and right is a list or object
     elsif (left.is_a?(Hocon::Impl::ConfigConcatenation)) ||
         (right.is_a?(Hocon::Impl::ConfigConcatenation))
       raise ConfigBugOrBrokenError, "unflattened ConfigConcatenation"

--- a/lib/hocon/impl/config_delayed_merge_object.rb
+++ b/lib/hocon/impl/config_delayed_merge_object.rb
@@ -63,7 +63,7 @@ class Hocon::Impl::ConfigDelayedMergeObject
   end
 
   def has_descendant?(descendant)
-    has_descendant_in_list?(@stack, descendant)
+    Hocon::Impl::AbstractConfigValue.has_descendant_in_list?(@stack, descendant)
   end
 
   def relativized(prefix)

--- a/lib/hocon/impl/parseable.rb
+++ b/lib/hocon/impl/parseable.rb
@@ -281,7 +281,7 @@ class Hocon::Impl::Parseable
   end
 
   def to_s
-    self.class.name
+    self.class.name.split('::').last
   end
 
   def self.syntax_from_extension(name)
@@ -371,7 +371,7 @@ class Hocon::Impl::Parseable
     end
 
     def to_s
-      "#{self.class.name} (#{@input})"
+      "#{self.class.name.split('::').last} (#{@input})"
     end
   end
 
@@ -435,7 +435,7 @@ class Hocon::Impl::Parseable
     end
 
     def to_s
-      "#{self.class.name} (#{@input})"
+      "#{self.class.name.split('::').last} (#{@input})"
     end
 
   end
@@ -517,7 +517,7 @@ class Hocon::Impl::Parseable
     end
 
     def to_s
-      "#{self.class.name}(#{@resource})"
+      "#{self.class.name.split('::').last}(#{@resource})"
     end
   end
 

--- a/lib/hocon/impl/parser.rb
+++ b/lib/hocon/impl/parser.rb
@@ -750,7 +750,8 @@ class Hocon::Impl::Parser
           inside_equals = false
 
           # path must be on-stack while we parse the value
-          @path_stack.push(path)
+          # Note that, in upstream, pathStack is a LinkedList, so use unshift instead of push
+          @path_stack.unshift(path)
 
           if after_key.token == Tokens::PLUS_EQUALS
             # we really should make this work, but for now throwing
@@ -812,7 +813,8 @@ class Hocon::Impl::Parser
 
           new_value = add_any_comments_after_any_comma(new_value)
 
-          last_path = @path_stack.pop
+          # Note that, in upstream, pathStack is a LinkedList, so use shift instead of pop
+          last_path = @path_stack.shift
           if inside_equals
             @equals_count -= 1
           end

--- a/lib/hocon/impl/path.rb
+++ b/lib/hocon/impl/path.rb
@@ -114,7 +114,7 @@ class Hocon::Impl::Path
 
   def last
     p = self
-    while not p.remainder.nil?
+    while p.remainder != nil
       p = p.remainder
     end
     p.first
@@ -132,17 +132,14 @@ class Hocon::Impl::Path
   def length
     count = 1
     p = remainder
-    while not p.nil? do
+    while p != nil do
       count += 1
       p = p.remainder
     end
-    return count
+    count
   end
 
-  def sub_path(first_index, last_index = nil)
-    if last_index.nil?
-      last_index = length - 1
-    end
+  def sub_path(first_index, last_index)
     if last_index < first_index
       raise ConfigBugOrBrokenError.new("bad call to sub_path")
     end
@@ -239,6 +236,10 @@ class Hocon::Impl::Path
     sb << ")"
 
     sb.string
+  end
+
+  def inspect
+    to_s
   end
 
   #

--- a/lib/hocon/impl/path_builder.rb
+++ b/lib/hocon/impl/path_builder.rb
@@ -29,7 +29,7 @@ class Hocon::Impl::PathBuilder
     remainder = path.remainder
 
     loop do
-      @keys << first
+      @keys.push(first)
 
       if !remainder.nil?
         first = remainder.first

--- a/lib/hocon/impl/path_parser.rb
+++ b/lib/hocon/impl/path_parser.rb
@@ -125,17 +125,16 @@ class Hocon::Impl::PathParser
           # We need to split the tokens on a . so that we can get sub-paths but still preserve
           # the original path text when doing an insertion
           if ! path_tokens.nil?
-            path_tokens.remove(path_tokens.size - 1)
-            path_tokens.add_all(split_token_on_period(t, flavor))
+            path_tokens.delete_at(path_tokens.size - 1)
+            path_tokens.concat(split_token_on_period(t, flavor))
           end
-
           text = v.transform_to_string
         elsif Tokens.unquoted_text?(t)
           # We need to split the tokens on a . so that we can get sub-paths but still preserve
           # the original path text when doing an insertion on ConfigNodeObjects
           if ! path_tokens.nil?
-            path_tokens.remove(path_tokens.size - 1)
-            path_tokens.add_all(split_token_on_period(t, flavor))
+            path_tokens.delete_at(path_tokens.size - 1)
+            path_tokens.concat(split_token_on_period(t, flavor))
           end
           text = Tokens.unquoted_text(t)
         else

--- a/lib/hocon/impl/resolve_result.rb
+++ b/lib/hocon/impl/resolve_result.rb
@@ -3,7 +3,9 @@
 require 'hocon'
 require 'hocon/impl'
 
+# value is allowed to be null
 class Hocon::Impl::ResolveResult
+  ConfigBugOrBrokenError = Hocon::ConfigError::ConfigBugOrBrokenError
 
   attr_accessor :context, :value
 
@@ -16,7 +18,22 @@ class Hocon::Impl::ResolveResult
     self.new(context, value)
   end
 
+  def as_object_result
+    unless @value.is_a?(Hocon::Impl::AbstractConfigObject)
+      raise ConfigBugOrBrokenError.new("Expecting a resolve result to be an object, but it was #{@value}")
+    end
+    self
+  end
+
+  def as_value_result
+    self
+  end
+
   def pop_trace
     self.class.make(@context.pop_trace, value)
+  end
+
+  def to_s
+    "ResolveResult(#{@value})"
   end
 end

--- a/lib/hocon/impl/resolve_source.rb
+++ b/lib/hocon/impl/resolve_source.rb
@@ -159,7 +159,7 @@ class Hocon::Impl::ResolveSource
       end
     else
       if old.equal?(@root)
-        return self.class.new(rust_must_be_obj(replacement))
+        return self.class.new(root_must_be_obj(replacement))
       else
         raise ConfigBugOrBrokenError.new("attempt to replace root #{root} with #{replacement}")
       end

--- a/lib/hocon/impl/simple_config_list.rb
+++ b/lib/hocon/impl/simple_config_list.rb
@@ -59,7 +59,7 @@ class Hocon::Impl::SimpleConfigList
   end
 
   def has_descendant?(descendant)
-    has_descendant_in_list?(@value, descendant)
+    Hocon::Impl::AbstractConfigValue.has_descendant_in_list?(@value, descendant)
   end
 
   def modify(modifier, new_resolve_status)
@@ -101,9 +101,9 @@ class Hocon::Impl::SimpleConfigList
 
     if changed != nil
       if new_resolve_status != nil
-        SimpleConfigList.new(origin, changed, new_resolve_status)
+        self.class.new(origin, changed, new_resolve_status)
       else
-        SimpleConfigList.new(origin, changed)
+        self.class.new(origin, changed)
       end
     else
       self
@@ -142,8 +142,6 @@ class Hocon::Impl::SimpleConfigList
         raise e
       rescue RuntimeError => e
         raise e
-      rescue Exception => e
-        raise ConfigBugOrBrokenError("unexpected exception", e)
       end
     end
   end

--- a/lib/hocon/impl/simple_config_origin.rb
+++ b/lib/hocon/impl/simple_config_origin.rb
@@ -337,12 +337,19 @@ class Hocon::Impl::SimpleConfigOrigin
     elsif stack.length == 2
       merge_two(stack[0], stack[1])
     else
-      remaining = stack.clone
-      while remaining.length > 2
-        merged = merge_three(remaining[-3], remaining[-2], remaining[-1])
-        remaining.pop
-        remaining.pop
-        remaining.pop
+      remaining = []
+      stack.each do |o|
+        remaining << o
+      end
+      while remaining.size > 2
+        c = remaining.last
+        remaining.delete_at(remaining.size - 1)
+        b = remaining.last
+        remaining.delete_at(remaining.size - 1)
+        a = remaining.last
+        remaining.delete_at(remaining.size - 1)
+
+        merged = merge_three(a, b, c)
 
         remaining << merged
       end

--- a/spec/unit/typesafe/config/concatenation_spec.rb
+++ b/spec/unit/typesafe/config/concatenation_spec.rb
@@ -55,22 +55,21 @@ describe "concatenation" do
     expect(e.message).to include("[1,2]")
   end
 
-  # FIXME
-  # it "no objects substituted in string concat" do
-  #   e = TestUtils.intercept(Hocon::ConfigError::ConfigWrongTypeError) {
-  #     TestUtils.parse_config(" a : abc ${x}, x : { y : z } ")
-  #   }
-  #   expect(e.message).to include("Cannot concatenate")
-  #   expect(e.message).to include("abc")
-  # end
-  #
-  # it "no arrays substituted in string concat" do
-  #   e = TestUtils.intercept(Hocon::ConfigError::ConfigWrongTypeError) {
-  #     TestUtils.parse_config(" a : abc ${x}, x : [1,2] ")
-  #   }
-  #   expect(e.message).to include("Cannot concatenate")
-  #   expect(e.message).to include("abc")
-  # end
+  it "no objects substituted in string concat" do
+    e = TestUtils.intercept(Hocon::ConfigError::ConfigWrongTypeError) {
+      TestUtils.parse_config(" a : abc ${x}, x : { y : z } ").resolve
+    }
+    expect(e.message).to include("Cannot concatenate")
+    expect(e.message).to include("abc")
+  end
+
+  it "no arrays substituted in string concat" do
+    e = TestUtils.intercept(Hocon::ConfigError::ConfigWrongTypeError) {
+      TestUtils.parse_config(" a : abc ${x}, x : [1,2] ").resolve
+    }
+    expect(e.message).to include("Cannot concatenate")
+    expect(e.message).to include("abc")
+  end
 
   it "no substitutions in list concat" do
     conf = TestUtils.parse_config(" a :  [1,2] [3,4]  ")
@@ -82,11 +81,10 @@ describe "concatenation" do
     expect([1, 2, 3, 4, 5, 6]).to eq(conf.get_list("a").unwrapped)
   end
 
-  # FIXME
-  # it "list concat self referential" do
-  #   conf = TestUtils.parse_config(" a : [1, 2], a : ${a} [3,4], a : ${a} [5,6]  ").resolve
-  #   expect([1, 2, 3, 4, 5, 6]).to eq(conf.get_list("a").unwrapped)
-  # end
+  it "list concat self referential" do
+    conf = TestUtils.parse_config(" a : [1, 2], a : ${a} [3,4], a : ${a} [5,6]  ").resolve
+    expect([1, 2, 3, 4, 5, 6]).to eq(conf.get_list("a").unwrapped)
+  end
 
   it "no substitutions in list concat cannot span lines" do
     e = TestUtils.intercept(Hocon::ConfigError::ConfigParseError) {
@@ -118,16 +116,15 @@ describe "concatenation" do
     expect({"a" => 0, "b" => 1, "c" => 2}).to eq(conf.get_object("a").unwrapped)
   end
 
-  # FIXME
-  # it "object concat self referential" do
-  #   conf = TestUtils.parse_config(" a : { a : 0 }, a : ${a} { b : 1 }, a : ${a} { c : 2 } ").resolve
-  #   expect({"a" => 0, "b" => 1, "c" => 2}).to eq(conf.get_object("a").unwrapped)
-  # end
-  #
-  # it "object concat self referential override" do
-  #   conf = TestUtils.parse_config(" a : { b : 3 }, a : { b : 2 } ${a} ").resolve
-  #   expect({"b" => 3}).to eq(conf.get_object("a").unwrapped)
-  # end
+  it "object concat self referential" do
+    conf = TestUtils.parse_config(" a : { a : 0 }, a : ${a} { b : 1 }, a : ${a} { c : 2 } ").resolve
+    expect({"a" => 0, "b" => 1, "c" => 2}).to eq(conf.get_object("a").unwrapped)
+  end
+
+  it "object concat self referential override" do
+    conf = TestUtils.parse_config(" a : { b : 3 }, a : { b : 2 } ${a} ").resolve
+    expect({"b" => 3}).to eq(conf.get_object("a").unwrapped)
+  end
 
   it "no substitutions object concat cannot span lines" do
     e = TestUtils.intercept(Hocon::ConfigError::ConfigParseError) {
@@ -199,89 +196,87 @@ describe "concatenation" do
     expect(e.message).to include("'['")
   end
 
-  # FIXME
-  # it "empty array plus equals" do
-  #   conf = TestUtils.parse_config(' a = [], a += 2 ').resolve
-  #   expect([2]).to eq(conf.get_int_list("a"))
-  # end
+  it "empty array plus equals" do
+    conf = TestUtils.parse_config(' a = [], a += 2 ').resolve
+    expect([2]).to eq(conf.get_int_list("a"))
+  end
 
   it "missing array plus equals" do
     conf = TestUtils.parse_config(' a += 2 ').resolve
     expect([2]).to eq(conf.get_int_list("a"))
   end
 
-  # FIXME
-  # it "short array plus equals" do
-  #   conf = TestUtils.parse_config(' a = [1], a += 2 ').resolve
-  #   expect([1, 2]).to eq(conf.get_int_list("a"))
-  # end
-  #
-  # it "number plus equals" do
-  #   e = TestUtils.intercept(Hocon::ConfigError::ConfigWrongTypeError) {
-  #     TestUtils.parse_config(' a = 10, a += 2 ').resolve
-  #   }
-  #   expect(e.message).to include("Cannot concatenate")
-  #   expect(e.message).to include("10")
-  #   expect(e.message).to include("[2]")
-  # end
-  #
-  # it "string plus equals" do
-  #   e = TestUtils.intercept(Hocon::ConfigError::ConfigWrongTypeError) {
-  #     TestUtils.parse_config(' a = abc, a += 2 ').resolve
-  #   }
-  #   expect(e.message).to include("Cannot concatenate")
-  #   expect(e.message).to include("abc")
-  #   expect(e.message).to include("[2]")
-  # end
-  #
-  # it "objects plus equals" do
-  #   e = TestUtils.intercept(Hocon::ConfigError::ConfigWrongTypeError) {
-  #     TestUtils.parse_config(' a = { x : y }, a += 2 ').resolve
-  #   }
-  #   expect(e.message).to include("Cannot concatenate")
-  #   expect(e.message).to include("\"x\":\"y\"")
-  #   expect(e.message).to include("[2]")
-  # end
-  #
-  # it "plus equals nested path" do
-  #   conf = TestUtils.parse_config(' a.b.c = [1], a.b.c += 2 ').resolve
-  #   expect([1, 2]).to eq(conf.get_int_list("a.b.c"))
-  # end
-  #
-  # it "plus equals nested object" do
-  #   conf = TestUtils.parse_config(' a : { b : { c : [1] } }, a : { b : { c += 2 } }').resolve
-  #   expect([1, 2]).to eq(conf.get_int_list("a.b.c"))
-  # end
-  #
-  # it "plus equals single nested object" do
-  #   conf = TestUtils.parse_config(' a : { b : { c : [1], c += 2 } }').resolve
-  #   expect([1, 2]).to eq(conf.get_int_list("a.b.c"))
-  # end
-  #
-  # it "substitution plus equals substitution" do
-  #   conf = TestUtils.parse_config(' a = ${x}, a += ${y}, x = [1], y = 2 ').resolve
-  #   expect([1, 2]).to eq(conf.get_int_list("a"))
-  # end
-  #
-  # it "plus equals multiple times" do
-  #   conf = TestUtils.parse_config(' a += 1, a += 2, a += 3 ').resolve
-  #   expect([1, 2, 3]).to eq(conf.get_int_list("a"))
-  # end
-  #
-  # it "plus equals multiple times nested" do
-  #   conf = TestUtils.parse_config(' x { a += 1, a += 2, a += 3 } ').resolve
-  #   expect([1, 2, 3]).to eq(conf.get_int_list("x.a"))
-  # end
-  #
-  # it "plus equals an object multiple times" do
-  #   conf = TestUtils.parse_config(' a += { b: 1 }, a += { b: 2 }, a += { b: 3 } ').resolve
-  #   expect([1, 2, 3]).to eq(conf.get_object_list("a").map { |x| x.to_config.get_int("b")})
-  # end
-  #
-  # it "plus equals an object multiple times nested" do
-  #   conf = TestUtils.parse_config(' x { a += { b: 1 }, a += { b: 2 }, a += { b: 3 } } ').resolve
-  #   expect([1, 2, 3]).to eq(conf.get_object_list("x.a").map { |x| x.to_config.get_int("b") })
-  # end
+  it "short array plus equals" do
+    conf = TestUtils.parse_config(' a = [1], a += 2 ').resolve
+    expect([1, 2]).to eq(conf.get_int_list("a"))
+  end
+
+  it "number plus equals" do
+    e = TestUtils.intercept(Hocon::ConfigError::ConfigWrongTypeError) {
+      TestUtils.parse_config(' a = 10, a += 2 ').resolve
+    }
+    expect(e.message).to include("Cannot concatenate")
+    expect(e.message).to include("10")
+    expect(e.message).to include("[2]")
+  end
+
+  it "string plus equals" do
+    e = TestUtils.intercept(Hocon::ConfigError::ConfigWrongTypeError) {
+      TestUtils.parse_config(' a = abc, a += 2 ').resolve
+    }
+    expect(e.message).to include("Cannot concatenate")
+    expect(e.message).to include("abc")
+    expect(e.message).to include("[2]")
+  end
+
+  it "objects plus equals" do
+    e = TestUtils.intercept(Hocon::ConfigError::ConfigWrongTypeError) {
+      TestUtils.parse_config(' a = { x : y }, a += 2 ').resolve
+    }
+    expect(e.message).to include("Cannot concatenate")
+    expect(e.message).to include("\"x\":\"y\"")
+    expect(e.message).to include("[2]")
+  end
+
+  it "plus equals nested path" do
+    conf = TestUtils.parse_config(' a.b.c = [1], a.b.c += 2 ').resolve
+    expect([1, 2]).to eq(conf.get_int_list("a.b.c"))
+  end
+
+  it "plus equals nested objects" do
+    conf = TestUtils.parse_config(' a : { b : { c : [1] } }, a : { b : { c += 2 } }').resolve
+    expect([1, 2]).to eq(conf.get_int_list("a.b.c"))
+  end
+
+  it "plus equals single nested object" do
+    conf = TestUtils.parse_config(' a : { b : { c : [1], c += 2 } }').resolve
+    expect([1, 2]).to eq(conf.get_int_list("a.b.c"))
+  end
+
+  it "substitution plus equals substitution" do
+    conf = TestUtils.parse_config(' a = ${x}, a += ${y}, x = [1], y = 2 ').resolve
+    expect([1, 2]).to eq(conf.get_int_list("a"))
+  end
+
+  it "plus equals multiple times" do
+    conf = TestUtils.parse_config(' a += 1, a += 2, a += 3 ').resolve
+    expect([1, 2, 3]).to eq(conf.get_int_list("a"))
+  end
+
+  it "plus equals multiple times nested" do
+    conf = TestUtils.parse_config(' x { a += 1, a += 2, a += 3 } ').resolve
+    expect([1, 2, 3]).to eq(conf.get_int_list("x.a"))
+  end
+
+  it "plus equals an object multiple times" do
+    conf = TestUtils.parse_config(' a += { b: 1 }, a += { b: 2 }, a += { b: 3 } ').resolve
+    expect([1, 2, 3]).to eq(conf.get_object_list("a").map { |x| x.to_config.get_int("b")})
+  end
+
+  it "plus equals an object multiple times nested" do
+    conf = TestUtils.parse_config(' x { a += { b: 1 }, a += { b: 2 }, a += { b: 3 } } ').resolve
+    expect([1, 2, 3]).to eq(conf.get_object_list("x.a").map { |x| x.to_config.get_int("b") })
+  end
 
   # We would ideally make this case NOT throw an exception but we need to do some work
   # to get there, see https: // github.com/typesafehub/config/issues/160
@@ -303,60 +298,58 @@ describe "concatenation" do
     expect(e.message).to include("limitation")
   end
 
-  # FIXME
-  # # from https://github.com/typesafehub/config/issues/177
-  # it "array concatenation in double nested delayed merge" do
-  #   unresolved = TestUtils.parse_config("d { x = [] }, c : ${d}, c { x += 1, x += 2 }")
-  #   conf = unresolved.resolve
-  #   expect([1,2]).to eq(conf.get_int_list("c.x"))
-  # end
-  #
-  # # from https://github.com/typesafehub/config/issues/177
-  # it "array concatenation as part of delayed merge" do
-  #   unresolved = TestUtils.parse_config(" c { x: [], x : ${c.x}[1], x : ${c.x}[2] }")
-  #   conf = unresolved.resolve
-  #   expect([1,2]).to eq(conf.get_int_list("c.x"))
-  # end
-  #
-  # # from https://github.com/typesafehub/config/issues/177
-  # it "array concatenation in double nested delayed merge 2" do
-  #   unresolved = TestUtils.parse_config("d { x = [] }, c : ${d}, c { x : ${c.x}[1], x : ${c.x}[2] }")
-  #   conf = unresolved.resolve
-  #   expect([1,2]).to eq(conf.get_int_list("c.x"))
-  # end
-  #
-  # # from https://github.com/typesafehub/config/issues/177
-  # it "array concatenation in triple nested delayed merge" do
-  #   unresolved = TestUtils.parse_config("{ r: { d.x=[] }, q: ${r}, q : { d { x = [] }, c : ${q.d}, c { x : ${q.c.x}[1], x : ${q.c.x}[2] } } }")
-  #   conf = unresolved.resolve
-  #   expect([1,2]).to eq(conf.get_int_list("q.c.x"))
-  # end
-  #
-  # it "concat undefined substitution with string" do
-  #   conf = TestUtils.parse_config("a = foo${?bar}").resolve
-  #   expect("foo").to eq(conf.get_string("a"))
-  # end
-  #
-  # it "concat defined optional substitution with string" do
-  #   conf = TestUtils.parse_config("a = foo${?bar}").resolve
-  #   expect("foo").to eq(conf.get_string("a"))
-  # end
-  #
-  # it "concat defined substitution with array" do
-  #   conf = TestUtils.parse_config("a = [1] ${?bar}").resolve
-  #   expect([1]).to eq(conf.get_int_list("a"))
-  # end
+  # from https://github.com/typesafehub/config/issues/177
+  it "array concatenation in double nested delayed merge" do
+    unresolved = TestUtils.parse_config("d { x = [] }, c : ${d}, c { x += 1, x += 2 }")
+    conf = unresolved.resolve
+    expect([1,2]).to eq(conf.get_int_list("c.x"))
+  end
+
+  # from https://github.com/typesafehub/config/issues/177
+  it "array concatenation as part of delayed merge" do
+    unresolved = TestUtils.parse_config(" c { x: [], x : ${c.x}[1], x : ${c.x}[2] }")
+    conf = unresolved.resolve
+    expect([1,2]).to eq(conf.get_int_list("c.x"))
+  end
+
+  # from https://github.com/typesafehub/config/issues/177
+  it "array concatenation in double nested delayed merge 2" do
+    unresolved = TestUtils.parse_config("d { x = [] }, c : ${d}, c { x : ${c.x}[1], x : ${c.x}[2] }")
+    conf = unresolved.resolve
+    expect([1,2]).to eq(conf.get_int_list("c.x"))
+  end
+
+  # from https://github.com/typesafehub/config/issues/177
+  it "array concatenation in triple nested delayed merge" do
+    unresolved = TestUtils.parse_config("{ r: { d.x=[] }, q: ${r}, q : { d { x = [] }, c : ${q.d}, c { x : ${q.c.x}[1], x : ${q.c.x}[2] } } }")
+    conf = unresolved.resolve
+    expect([1,2]).to eq(conf.get_int_list("q.c.x"))
+  end
+
+  it "concat undefined substitution with string" do
+    conf = TestUtils.parse_config("a = foo${?bar}").resolve
+    expect("foo").to eq(conf.get_string("a"))
+  end
+
+  it "concat defined optional substitution with string" do
+    conf = TestUtils.parse_config("bar=bar, a = foo${?bar}").resolve
+    expect("foobar").to eq(conf.get_string("a"))
+  end
+
+  it "concat defined substitution with array" do
+    conf = TestUtils.parse_config("a = [1] ${?bar}").resolve
+    expect([1]).to eq(conf.get_int_list("a"))
+  end
 
   it "concat defined optional substitution with array" do
     conf = TestUtils.parse_config("bar=[2], a = [1] ${?bar}").resolve
     expect([1, 2]).to eq(conf.get_int_list("a"))
   end
 
-  # FIXME
-  # it "concat undefined substitution with object" do
-  #   conf = TestUtils.parse_config('a = { x : "foo" } ${?bar}').resolve
-  #   expect('foo').to eq(conf.get_string("a.x"))
-  # end
+  it "concat undefined substitution with object" do
+    conf = TestUtils.parse_config('a = { x : "foo" } ${?bar}').resolve
+    expect('foo').to eq(conf.get_string("a.x"))
+  end
 
   it "concat defined optional substitution with object" do
     conf = TestUtils.parse_config('bar={ y : 42 }, a = { x : "foo" } ${?bar}').resolve
@@ -364,32 +357,30 @@ describe "concatenation" do
     expect(42).to eq(conf.get_int("a.y"))
   end
 
-  # FIXME
-  # it "concat two undefined substitutions" do
-  #   conf = TestUtils.parse_config("a = ${?foo}${?bar}").resolve
-  #   expect(conf.has_path("a")).to be_false
-  # end
-  #
-  # it "concat several undefined substitutions" do
-  #   conf = TestUtils.parse_config("a = ${?foo}${?bar}${?baz}${?woooo}").resolve
-  #   expect(conf.has_path("a")).to be_false
-  # end
-  #
-  # it "concat two undefined substitutions with a space" do
-  #   conf = TestUtils.parse_config("a = ${?foo} ${?bar}").resolve
-  #   expect(conf.get_string("a")).to eq(" ")
-  # end
+  it "concat two undefined substitutions" do
+    conf = TestUtils.parse_config("a = ${?foo}${?bar}").resolve
+    expect(conf.has_path?("a")).to be_false
+  end
+
+  it "concat several undefined substitutions" do
+    conf = TestUtils.parse_config("a = ${?foo}${?bar}${?baz}${?woooo}").resolve
+    expect(conf.has_path?("a")).to be_false
+  end
+
+  it "concat two undefined substitutions with a space" do
+    conf = TestUtils.parse_config("a = ${?foo} ${?bar}").resolve
+    expect(conf.get_string("a")).to eq(" ")
+  end
 
   it "concat two defined substitutions with a space" do
     conf = TestUtils.parse_config("foo=abc, bar=def, a = ${foo} ${bar}").resolve
     expect(conf.get_string("a")).to eq("abc def")
   end
 
-  # FIXME
-  # it "concat two undefined substitutions with empty string" do
-  #   conf = TestUtils.parse_config('a = ""${?foo}${?bar}').resolve
-  #   expect(conf.get_string("a")).to eq("")
-  # end
+  it "concat two undefined substitutions with empty string" do
+    conf = TestUtils.parse_config('a = ""${?foo}${?bar}').resolve
+    expect(conf.get_string("a")).to eq("")
+  end
 
   it "concat substitutions that are objects with no space" do
     conf = TestUtils.parse_config('foo = { a : 1}, bar = { b : 2 }, x = ${foo}${bar}').resolve
@@ -397,19 +388,18 @@ describe "concatenation" do
     expect(2).to eq(conf.get_int("x.b"))
   end
 
-  # FIXME
-  # # whitespace is insignificant if substitutions don't turn out to be a string
-  # it "concat substitutions that are objects with space" do
-  #   conf = TestUtils.parse_config('foo = { a : 1}, bar = { b : 2 }, x = ${foo} ${bar}').resolve
-  #   expect(1).to eq(conf.get_int("x.a"))
-  #   expect(2).to eq(conf.get_int("x.b"))
-  # end
-  #
-  # # whitespace is insignificant if substitutions don't turn out to be a string
-  # it "concat substitutions that are lists with space" do
-  #   conf = TestUtils.parse_config('foo = [1], bar = [2], x = ${foo} ${bar}').resolve
-  #   expect([1,2]).to eq(conf.get_int_list("x"))
-  # end
+  # whitespace is insignificant if substitutions don't turn out to be a string
+  it "concat substitutions that are objects with space" do
+    conf = TestUtils.parse_config('foo = { a : 1}, bar = { b : 2 }, x = ${foo} ${bar}').resolve
+    expect(1).to eq(conf.get_int("x.a"))
+    expect(2).to eq(conf.get_int("x.b"))
+  end
+
+  # whitespace is insignificant if substitutions don't turn out to be a string
+  it "concat substitutions that are lists with space" do
+    conf = TestUtils.parse_config('foo = [1], bar = [2], x = ${foo} ${bar}').resolve
+    expect([1,2]).to eq(conf.get_int_list("x"))
+  end
 
   # but quoted whitespace should be an error
   it "concat substitutions that are objects with quoted space" do


### PR DESCRIPTION
Un-comment the remaining concatenation test cases that were still commented-out
and fix bugs.  Also added 'inspect' implementations and use short class names to
make trace output match upstream, and re-wrote various bits of code to correspond
more closely to upstream.