### PR TITLE
(TK-186) Port ConfigNode tests

### DIFF
--- a/lib/hocon/impl/abstract_config_node.rb
+++ b/lib/hocon/impl/abstract_config_node.rb
@@ -1,10 +1,10 @@
 # encoding: utf-8
 
 require 'hocon/impl'
-require 'hocon/config_node'
+require 'hocon/parser/config_node'
 require 'hocon/config_error'
 
-class Hocon::Impl::AbstractConfigNode < Hocon::ConfigNode
+class Hocon::Impl::AbstractConfigNode < Hocon::Parser::ConfigNode
   def tokens
     raise Hocon::ConfigError::ConfigBugOrBrokenError, "subclasses of AbstractConfigNode should override `tokens` (#{self.class})"
   end

--- a/lib/hocon/impl/abstract_config_node.rb
+++ b/lib/hocon/impl/abstract_config_node.rb
@@ -4,7 +4,8 @@ require 'hocon/impl'
 require 'hocon/parser/config_node'
 require 'hocon/config_error'
 
-class Hocon::Impl::AbstractConfigNode < Hocon::Parser::ConfigNode
+module Hocon::Impl::AbstractConfigNode
+  include Hocon::Parser::ConfigNode
   def tokens
     raise Hocon::ConfigError::ConfigBugOrBrokenError, "subclasses of AbstractConfigNode should override `tokens` (#{self.class})"
   end

--- a/lib/hocon/impl/abstract_config_node_value.rb
+++ b/lib/hocon/impl/abstract_config_node_value.rb
@@ -3,9 +3,9 @@
 require 'hocon/impl'
 require 'hocon/impl/abstract_config_node'
 
-# This is required if we want
-# to be referencing the AbstractConfigNode class in implementation rather than the
-# ConfigNode interface, as we can't cast an AbstractConfigNode to an interface
+# This essentially exists in the upstream so we can ensure only certain types of
+# config nodes can be passed into some methods. That's not a problem in Ruby, so this is
+# unnecessary, but it seems best to keep it around for consistency
 module Hocon::Impl::AbstractConfigNodeValue
   include Hocon::Impl::AbstractConfigNode
 end

--- a/lib/hocon/impl/abstract_config_node_value.rb
+++ b/lib/hocon/impl/abstract_config_node_value.rb
@@ -1,0 +1,11 @@
+# encoding: utf-8
+
+require 'hocon/impl'
+require 'hocon/impl/abstract_config_node'
+
+# This is required if we want
+# to be referencing the AbstractConfigNode class in implementation rather than the
+# ConfigNode interface, as we can't cast an AbstractConfigNode to an interface
+class Hocon::Impl::AbstractConfigNodeValue < Hocon::Impl::AbstractConfigNode
+
+end

--- a/lib/hocon/impl/abstract_config_node_value.rb
+++ b/lib/hocon/impl/abstract_config_node_value.rb
@@ -6,6 +6,6 @@ require 'hocon/impl/abstract_config_node'
 # This is required if we want
 # to be referencing the AbstractConfigNode class in implementation rather than the
 # ConfigNode interface, as we can't cast an AbstractConfigNode to an interface
-class Hocon::Impl::AbstractConfigNodeValue < Hocon::Impl::AbstractConfigNode
-
+module Hocon::Impl::AbstractConfigNodeValue
+  include Hocon::Impl::AbstractConfigNode
 end

--- a/lib/hocon/impl/config_node_array.rb
+++ b/lib/hocon/impl/config_node_array.rb
@@ -3,7 +3,8 @@
 require 'hocon/impl'
 require 'hocon/impl/config_node_complex_value'
 
-class Hocon::Impl::ConfigNodeArray < Hocon::Impl::ConfigNodeComplexValue
+class Hocon::Impl::ConfigNodeArray
+  include Hocon::Impl::ConfigNodeComplexValue
   def new_node(nodes)
     self.class.new(nodes)
   end

--- a/lib/hocon/impl/config_node_array.rb
+++ b/lib/hocon/impl/config_node_array.rb
@@ -1,0 +1,10 @@
+# encoding: utf-8
+
+require 'hocon/impl'
+require 'hocon/impl/config_node_complex_value'
+
+class Hocon::Impl::ConfigNodeArray < Hocon::Impl::ConfigNodeComplexValue
+  def new_node(nodes)
+    self.class.new(nodes)
+  end
+end

--- a/lib/hocon/impl/config_node_comment.rb
+++ b/lib/hocon/impl/config_node_comment.rb
@@ -1,0 +1,19 @@
+# encoding: utf-8
+
+require 'hocon/impl'
+require 'hocon/config_error'
+require 'hocon/impl/config_node_single_token'
+require 'hocon/impl/tokens'
+
+class Hocon::Impl::ConfigNodeComment < Hocon::Impl::ConfigNodeSingleToken
+  def initialize(comment)
+    super(comment)
+    if !Hocon::Impl::Tokens.comment?(@token)
+      raise Hocon::ConfigError::ConfigBugOrBrokenError, 'Tried to create a ConfigNodeComment from a non-comment token'
+    end
+  end
+
+  def commentText
+    Hocon::Impl::Tokens.comment_text(@token)
+  end
+end

--- a/lib/hocon/impl/config_node_comment.rb
+++ b/lib/hocon/impl/config_node_comment.rb
@@ -8,12 +8,12 @@ require 'hocon/impl/tokens'
 class Hocon::Impl::ConfigNodeComment < Hocon::Impl::ConfigNodeSingleToken
   def initialize(comment)
     super(comment)
-    if !Hocon::Impl::Tokens.comment?(@token)
+    unless Hocon::Impl::Tokens.comment?(@token)
       raise Hocon::ConfigError::ConfigBugOrBrokenError, 'Tried to create a ConfigNodeComment from a non-comment token'
     end
   end
 
-  def commentText
+  def comment_text
     Hocon::Impl::Tokens.comment_text(@token)
   end
 end

--- a/lib/hocon/impl/config_node_complex_value.rb
+++ b/lib/hocon/impl/config_node_complex_value.rb
@@ -8,7 +8,8 @@ require 'hocon/impl/config_node_single_token'
 require 'hocon/impl/tokens'
 require 'hocon/config_error'
 
-class Hocon::Impl::ConfigNodeComplexValue < Hocon::Impl::AbstractConfigNodeValue
+module Hocon::Impl::ConfigNodeComplexValue
+  include Hocon::Impl::AbstractConfigNodeValue
   def initialize(children)
     @children = children
   end

--- a/lib/hocon/impl/config_node_complex_value.rb
+++ b/lib/hocon/impl/config_node_complex_value.rb
@@ -1,0 +1,53 @@
+# encoding: utf-8
+
+require 'hocon/impl'
+require 'hocon/impl/abstract_config_node_value'
+require 'hocon/impl/config_node_field'
+require 'hocon/impl/config_node_include'
+require 'hocon/impl/config_node_single_token'
+require 'hocon/impl/tokens'
+require 'hocon/config_error'
+
+class Hocon::Impl::ConfigNodeComplexValue < Hocon::Impl::AbstractConfigNodeValue
+  def initialize(children)
+    @children = children
+  end
+
+  attr_reader :children
+
+  def tokens
+    tokens = []
+    @children.each do |child|
+      tokens += child.tokens
+    end
+    tokens
+  end
+
+  def indent_text(indentation)
+    children_copy = @children.clone
+    i = 0
+    while i < children_copy.size
+      child = children_copy[i]
+      if child.is_a?(Hocon::Impl::ConfigNodeSingleToken) && Hocon::Impl::Tokens.newline?(child.token)
+        children_copy.insert(i + 1, indentation)
+        i += 1
+      elsif child.is_a?(Hocon::Impl::ConfigNodeField)
+        value = child.value
+        if value.is_a?(self.class)
+          children_copy[i] = child.replace_value(value.indent_text(indentation))
+        end
+      elsif child.is_a?(self.class)
+        children_copy[i] = child.indent_text(indentation)
+      end
+      i += 1
+    end
+    new_node(children_copy)
+  end
+
+  # This method will just call into the object's constructor, but it's needed
+  # for use in the indentText() method so we can avoid a gross if/else statement
+  # checking the type of this
+  def new_node(nodes)
+    raise Hocon::ConfigError::ConfigBugOrBrokenError, "subclasses of ConfigNodeComplexValue should override `new_node` (#{self.class})"
+  end
+end

--- a/lib/hocon/impl/config_node_concatenation.rb
+++ b/lib/hocon/impl/config_node_concatenation.rb
@@ -1,0 +1,10 @@
+# encoding: utf-8
+
+require 'hocon/impl'
+require 'hocon/impl/config_node_complex_value'
+
+class Hocon::Impl::ConfigNodeConcatenation < Hocon::Impl::ConfigNodeComplexValue
+  def new_node(nodes)
+    self.class.new(nodes)
+  end
+end

--- a/lib/hocon/impl/config_node_concatenation.rb
+++ b/lib/hocon/impl/config_node_concatenation.rb
@@ -3,7 +3,8 @@
 require 'hocon/impl'
 require 'hocon/impl/config_node_complex_value'
 
-class Hocon::Impl::ConfigNodeConcatenation < Hocon::Impl::ConfigNodeComplexValue
+class Hocon::Impl::ConfigNodeConcatenation
+  include Hocon::Impl::ConfigNodeComplexValue
   def new_node(nodes)
     self.class.new(nodes)
   end

--- a/lib/hocon/impl/config_node_field.rb
+++ b/lib/hocon/impl/config_node_field.rb
@@ -9,7 +9,8 @@ require 'hocon/impl/config_node_path'
 require 'hocon/impl/config_node_single_token'
 require 'hocon/impl/tokens'
 
-class Hocon::Impl::ConfigNodeField < Hocon::Impl::AbstractConfigNode
+class Hocon::Impl::ConfigNodeField
+  include Hocon::Impl::AbstractConfigNode
 
   Tokens = Hocon::Impl::Tokens
 

--- a/lib/hocon/impl/config_node_field.rb
+++ b/lib/hocon/impl/config_node_field.rb
@@ -29,9 +29,8 @@ class Hocon::Impl::ConfigNodeField < Hocon::Impl::AbstractConfigNode
 
   def replace_value(new_value)
     children_copy = @children.clone
-    i = 0
-    while i < children_copy.size
-      if children_copy[i].is_a?(Hocon::Impl::AbstractConfigNodeValue)
+    children_copy.each_with_index do |child, i|
+      if child.is_a?(Hocon::Impl::AbstractConfigNodeValue)
         children_copy[i] = new_value
         return self.class.new(children_copy)
       end

--- a/lib/hocon/impl/config_node_field.rb
+++ b/lib/hocon/impl/config_node_field.rb
@@ -1,0 +1,81 @@
+# encoding: utf-8
+
+require 'hocon/impl'
+require 'hocon/config_error'
+require 'hocon/impl/abstract_config_node'
+require 'hocon/impl/abstract_config_node_value'
+require 'hocon/impl/config_node_comment'
+require 'hocon/impl/config_node_path'
+require 'hocon/impl/config_node_single_token'
+require 'hocon/impl/tokens'
+
+class Hocon::Impl::ConfigNodeField < Hocon::Impl::AbstractConfigNode
+
+  Tokens = Hocon::Impl::Tokens
+
+  def initialize(children)
+    @children = children
+  end
+
+  attr_reader :children
+
+  def tokens
+    tokens = []
+    @children.each do |child|
+      tokens += child.tokens
+    end
+    tokens
+  end
+
+  def replace_value(new_value)
+    children_copy = @children.clone
+    i = 0
+    while i < children_copy.size
+      if children_copy[i].is_a?(Hocon::Impl::AbstractConfigNodeValue)
+        children_copy[i] = new_value
+        return self.class.new(children_copy)
+      end
+    end
+    raise Hocon::ConfigError::ConfigBugOrBrokenError, "Field node doesn't have a value"
+  end
+
+  def value
+    @children.each do |child|
+      if child.is_a?(Hocon::Impl::AbstractConfigNodeValue)
+        return child
+      end
+    end
+    raise Hocon::ConfigError::ConfigBugOrBrokenError, "Field node doesn't have a value"
+  end
+
+  def path
+    @children.each do |child|
+      if child.is_a?(Hocon::Impl::ConfigNodePath)
+        return child
+      end
+    end
+    raise Hocon::ConfigError::ConfigBugOrBrokenError, "Field node doesn't have a path"
+  end
+
+  def separator
+    @children.each do |child|
+      if child.is_a?(Hocon::Impl::ConfigNodeSingleToken)
+        t = child.token
+        if t == Tokens::PLUS_EQUALS or t == Tokens::COLON or t == Tokens::EQUALS
+          return t
+        end
+      end
+    end
+    nil
+  end
+
+  def comments
+    comments = []
+    @children.each do |child|
+      if child.is_a?(Hocon::Impl::ConfigNodeComment)
+        comments += child.comment_text
+      end
+    end
+    comments
+  end
+end

--- a/lib/hocon/impl/config_node_include.rb
+++ b/lib/hocon/impl/config_node_include.rb
@@ -1,0 +1,32 @@
+# encoding: utf-8
+
+require 'hocon/impl'
+require 'hocon/config_error'
+require 'hocon/impl/abstract_config_node'
+require 'hocon/impl/config_node_simple_value'
+
+class Hocon::Impl::ConfigNodeInclude < Hocon::Impl::AbstractConfigNodeValue
+  def initialize(children, kind)
+    @children = children
+    @kind = kind
+  end
+
+  attr_reader :kind, :children
+
+  def tokens
+    tokens = []
+    @children.each do |child|
+      tokens += child.tokens
+    end
+    tokens
+  end
+
+  def name
+    @children.each do |child|
+      if child.is_a?(Hocon::Impl::ConfigNodeSimpleValue)
+        return Hocon::Impl::Tokens.value(n.token).unwrapped
+      end
+    end
+    nil
+  end
+end

--- a/lib/hocon/impl/config_node_include.rb
+++ b/lib/hocon/impl/config_node_include.rb
@@ -5,7 +5,8 @@ require 'hocon/config_error'
 require 'hocon/impl/abstract_config_node'
 require 'hocon/impl/config_node_simple_value'
 
-class Hocon::Impl::ConfigNodeInclude < Hocon::Impl::AbstractConfigNodeValue
+class Hocon::Impl::ConfigNodeInclude
+  include Hocon::Impl::AbstractConfigNode
   def initialize(children, kind)
     @children = children
     @kind = kind

--- a/lib/hocon/impl/config_node_object.rb
+++ b/lib/hocon/impl/config_node_object.rb
@@ -1,0 +1,279 @@
+# encoding: utf-8
+
+require 'hocon/config_syntax'
+require 'hocon/impl'
+require 'hocon/impl/config_node_complex_value'
+require 'hocon/impl/config_node_field'
+require 'hocon/impl/config_node_single_token'
+require 'hocon/impl/tokens'
+
+class Hocon::Impl::ConfigNodeObject < Hocon::Impl::ConfigNodeComplexValue
+
+  ConfigSyntax = Hocon::ConfigSyntax
+  Tokens = Hocon::Impl::Tokens
+
+  def new_node(nodes)
+    self.class.new(nodes)
+  end
+
+  def has_value(desired_path)
+    @children.each do |node|
+      if node.is_a?(Hocon::Impl::ConfigNodeField)
+        field = node
+        key = field.path.value
+        if key == desired_path || key.starts_with(desired_path)
+          return true
+        elsif desired_path.starts_with(key)
+          if field.value.is_a?(self.class)
+            obj = field.value
+            remaining_path = desired_path.sub_path(key.length)
+            if obj.has_value(remaining_path)
+              return true
+            end
+          end
+        end
+      end
+    end
+    false
+  end
+
+  def change_value_on_path(desired_path, value, flavor)
+    children_copy = @children.clone
+    seen_non_matching = false
+    # Copy the value so we can change it to null but not modify the original parameter
+    value_copy = value
+    i = children_copy.size
+    while i >= 0 do
+      if children_copy[i].is_a?(Hocon::Impl::ConfigNodeSingleToken)
+        t = children_copy[i].token
+        # Ensure that, when we are removing settings in JSON, we don't end up with a trailing comma
+        if flavor.equal?(ConfigSyntax::JSON) && !seen_non_matching && t.equal?(Tokens::COMMA)
+          children_copy.delete_at(i)
+        end
+        i -= 1
+        next
+      elsif !children_copy[i].is_a?(Hocon::Impl::ConfigNodeField)
+        i -= 1
+        next
+      end
+      node = children_copy[i]
+      key = node.path.value
+
+      # Delete all multi-element paths that start with the desired path, since technically they are duplicates
+      if (value_copy.nil? && key == desired_path) || (key.starts_with(desired_path) && !(key == desired_path))
+        children_copy.delete_at(i)
+        # Remove any whitespace or commas after the deleted setting
+        j = i
+        while j < children_copy.size
+          if children_copy[j].is_a?(Hocon::Impl::ConfigNodeSingleToken)
+            t = children_copy[j].token
+            if Tokens.ignored_whitespace?(t) || t.equal?(Tokens::COMMA)
+              children_copy.delete_at[j]
+              j -= 1
+            else
+              break
+            end
+          else
+            break
+          end
+          j += 1
+        end
+      elsif key == desired_path
+        seen_non_matching = true
+        before = i - 1 > 0 ? children_copy[i - 1] : nil
+        if value.is_a?(Hocon::Impl::ConfigNodeComplexValue) && before.is_a?(Hocon::Impl::ConfigNodeSingleToken) &&
+            Tokens.ignored_whitespace?(before.token)
+          indented_value = value.indent_text(before)
+        else
+          indented_value = value
+        end
+        children_copy[i] = node.replace_value(indented_value)
+        value_copy = nil
+      elsif desired_path.starts_with(key)
+        seen_non_matching = true
+        if node.value.is_a?(self.class)
+          remaining_path = desired_path.sub_path(key.length)
+          children_copy[i] = node.replace_value(node.value.change_value_on_path(remaining_path, value_copy, flavor))
+          if !value_copy.nil? && !(node == @children[i])
+            value_copy = nil
+          end
+        end
+      else
+        seen_non_matching = true
+      end
+      i -= 1
+    end
+    self.class.new(children_copy)
+  end
+
+  def set_value_on_path(desired_path, value, flavor = ConfigSyntax::CONF)
+    path = Hocon::Impl::PathParser.parse_path_node(desired_path, flavor)
+    set_value_on_path_node(path, value, flavor)
+  end
+
+  def set_value_on_path_node(desired_path, value, flavor)
+    node = change_value_on_path(desired_path.value, value, flavor)
+
+    # If the desired Path did not exist, add it
+    unless node.has_value(desired_path.value)
+      return node.add_value_on_path(desired_path, value, flavor)
+    end
+    node
+  end
+
+  def indentation
+    seen_new_line = false
+    indentation = []
+    i = 0
+    while i < @children.size
+      unless seen_new_line
+        if @children[i].is_a?(Hocon::Impl::ConfigNodeSingleToken) && Tokens.newline?(@children[i].token)
+          seen_new_line = true
+          indentation += Hocon::Impl::ConfigNodeSingleToken.new(Tokens.new_line(nil))
+        end
+      else
+        if @children[i].is_a?(Hocon::Impl::ConfigNodeSingleToken) &&
+            Tokens.ignored_whitespace?(@children[i].token) &&
+            i + 1 < @children.size &&
+            (@children[i + 1].is_a?(Hocon::Impl::ConfigNodeField || @children[i + 1].is_a?(Hocon::Impl::ConfigNodeInclude)))
+          # Return the indentation of the first setting on its own line
+          indentation += @children[i]
+          return indentation
+        end
+      end
+      i += 1
+    end
+    if indentation.empty?
+      indentation += Hocon::Impl::ConfigNodeSingleToken.new(Tokens.new_ignored_whitespace(null, " "))
+      return indentation
+    else
+      # Calculate the indentation of the ending curly-brace to get the indentation of the root object
+      last = @children[-1]
+      if last.is_a?(Hocon::Impl::ConfigNodeSingleToken) && last.token.equal?(Tokens::CLOSE_CURLY)
+        beforeLast = @children[-2]
+        if beforeLast.is_a?(Hocon::Impl::ConfigNodeSingleToken) &&
+            Tokens.ignored_whitespace?(beforeLast.token)
+          indent = beforeLast.token.token_text
+          indent += "  "
+          indentation += Hocon::Impl::ConfigNodeSingleToken.new(Tokens.new_ignored_whitespace(null, indent))
+          return indentation
+        end
+      end
+    end
+
+    # The object has no curly braces and is at the root level, so don't indent
+    indentation
+  end
+
+  def add_value_on_path(desired_path, value, flavor)
+    path = desired_path.value
+    children_copy = @children.clone
+    indentation = indentation().clone
+
+    # If the value we're inserting is a complex value, we'll need to indent it for insertion
+    if value.is_a?(Hocon::Impl::ConfigNodeComplexValue)
+      indented_value = value.indent_text(indentation[-1])
+    else
+      indented_value = value
+    end
+    same_line = !(indentation[0].is_a?(Hocon::Impl::ConfigNodeSingleToken) &&
+                    Tokens.newline?(indentation[0].token))
+
+    # If the path is of length greater than one, see if the value needs to be added further down
+    if path.length > 1
+      i = @children.size
+      while i >= 0
+        unless @children[i].is_a?(Hocon::Impl::ConfigNodeField)
+          i -= 1
+          next
+        end
+        node = @children[i]
+        key = node.path.value
+        if path.starts_with(key) && node.value.is_a?(self.class)
+          remaining_path = desired_path.sub_path(key.length)
+          new_value = node.value
+          children_copy[i] = node.replace_value(new_value.add_value_on_path(remaining_path, value, flavor))
+          return self.class.new(children_copy)
+        end
+        i -= 1
+      end
+    end
+
+    # Otherwise, construct the new setting
+    starts_with_brace = @children[0].is_a?(Hocon::Impl::ConfigNodeSingleToken) && @children[0].token.equal?(Tokens::OPEN_CURLY)
+    new_nodes = []
+    new_nodes += indentation
+    new_nodes += desired_path.first
+    new_nodes += Hocon::Impl::ConfigNodeSingleToken.new(Tokens.new_ignored_whitespace(nil, ' '))
+    new_nodes += Hocon::Impl::ConfigNodeSingleToken.new(Tokens.COLON)
+    new_nodes += Hocon::Impl::ConfigNodeSingleToken.new(Tokens.new_ignored_whitespace(nil, ' '))
+
+    if path.length == 1
+      new_nodes += indented_value
+    else
+      # If the path is of length greater than one add the required new objects along the path
+      new_object_nodes = []
+      new_object_nodes += Hocon::Impl::ConfigNodeSingleToken.new(Tokens::OPEN_CURLY)
+      new_object_nodes += Hocon::Impl::ConfigNodeSingleToken.new(Tokens.new_ignored_whitespace(nil, ' '))
+      new_object_nodes += Hocon::Impl::ConfigNodeSingleToken.new(Tokens::CLOSE_CURLY)
+      new_object = self.class.new(new_object_nodes)
+      new_nodes.add(new_object.add_value_on_path(desired_path.sub_path(1), indented_value, flavor))
+    end
+
+    # Combine these two cases so that we only have to iterate once
+    if flavor.equal?(ConfigSyntax::JSON) || starts_with_brace || same_line
+      i = children_copy.size - 1
+      while i >= 0
+
+        # If we are in JSON or are adding a setting on the same line, we need to add a comma to the
+        # last setting
+        if (flavor.equal?(ConfigSyntax::JSON) || same_line) && children_copy[i].is_a?(Hocon::Impl::ConfigNodeField)
+          if i + 1 >= children_copy.size ||
+              !(children_copy[i + 1].is_a?(Hocon::Impl::ConfigNodeSingleToken) && children_copy[i + 1].token.equal?(Tokens::COMMA))
+            children_copy.insert(i + 1, Hocon::Impl::ConfigNodeSingleToken.new(Tokens::COMMA))
+            break
+          end
+        end
+
+        # Add the value into the copy of the children map, keeping any whitespace/newlines
+        # before the close curly brace
+        if starts_with_brace && children_copy[i].is_a?(Hocon::Impl::ConfigNodeSingleToken) &&
+            children_copy[i].token == Tokens::CLOSE_CURLY
+          previous = children_copy[i - 1]
+          if previous.is_a?(Hocon::Impl::ConfigNodeSingleToken) && Tokens.newline?(previous.token)
+            children_copy.insert(i - 1, Hocon::Impl::ConfigNodeField.new(new_nodes))
+            i -= 1
+          elsif previous.is_a?(Hocon::Impl::ConfigNodeSingleToken) && Tokens.ignored_whitespace?(previous.token)
+            before_previous = children_copy[i - 2]
+            if same_line
+              children_copy.insert(i - 1, Hocon::Impl::ConfigNodeField.new(new_nodes))
+              i -= 1
+            elsif before_previous.is_a?(Hocon::Impl::ConfigNodeSingleToken) && Tokens.newline?(before_previous.token)
+              children_copy.insert(i - 2, Hocon::Impl::ConfigNodeField.new(new_nodes))
+              i -= 2
+            else
+              children_copy.insert(i, Hocon::Impl::ConfigNodeField.new(new_nodes))
+            end
+          else
+            children_copy.add(i, Hocon::Impl::ConfigNodeField.new(new_nodes))
+          end
+        end
+
+        i -= 1
+      end
+    end
+    unless starts_with_brace
+      if children_copy[-1].is_a(Hocon::Impl::ConfigNodeSingleToken) && Tokens.newline?(children_copy[-1].token)
+        children_copy.insert(-1, Hocon::Impl::ConfigNodeField.new(new_nodes))
+      else
+        children_copy += Hocon::Impl::ConfigNodeField.new(new_nodes)
+      end
+    end
+    self.class.new(children_copy)
+  end
+
+  def remove_value_on_path(desired_path, flavor)
+    path = Hocon::Impl::PathParser.parse_path_node(desired_path, flavor).value
+    change_value_on_path(path, nil, flavor)
+  end
+end

--- a/lib/hocon/impl/config_node_object.rb
+++ b/lib/hocon/impl/config_node_object.rb
@@ -7,7 +7,8 @@ require 'hocon/impl/config_node_field'
 require 'hocon/impl/config_node_single_token'
 require 'hocon/impl/tokens'
 
-class Hocon::Impl::ConfigNodeObject < Hocon::Impl::ConfigNodeComplexValue
+class Hocon::Impl::ConfigNodeObject
+  include Hocon::Impl::ConfigNodeComplexValue
 
   ConfigSyntax = Hocon::ConfigSyntax
   Tokens = Hocon::Impl::Tokens

--- a/lib/hocon/impl/config_node_path.rb
+++ b/lib/hocon/impl/config_node_path.rb
@@ -4,7 +4,8 @@ require 'hocon/impl'
 require 'hocon/impl/tokens'
 require 'hocon/impl/abstract_config_node'
 
-class Hocon::Impl::ConfigNodePath < Hocon::Impl::AbstractConfigNode
+class Hocon::Impl::ConfigNodePath
+  include Hocon::Impl::AbstractConfigNode
   Tokens = Hocon::Impl::Tokens
 
   def initialize(path, tokens)

--- a/lib/hocon/impl/config_node_path.rb
+++ b/lib/hocon/impl/config_node_path.rb
@@ -28,7 +28,7 @@ class Hocon::Impl::ConfigNodePath < Hocon::Impl::AbstractConfigNode
       end
 
       if period_count == to_remove
-        return ConfigNodePath.new(@path.sub_path(to_remove), tokens_copy[i + 1..tokens_copy.size])
+        return self.class.new(@path.sub_path_to_end(to_remove), tokens_copy[i + 1..tokens_copy.size])
       end
     end
     raise ConfigBugOrBrokenError, "Tried to remove too many elements from a Path node"
@@ -37,9 +37,9 @@ class Hocon::Impl::ConfigNodePath < Hocon::Impl::AbstractConfigNode
   def first
     tokens_copy = tokens.clone
     (0..tokens_copy.size - 1).each do |i|
-      if Tokens.is_unquoted_text(tokens_copy[i]) &&
+      if Tokens.unquoted_text?(tokens_copy[i]) &&
           tokens_copy[i].token_text == "."
-        ConfigNodePath.new(@path[0, 1], tokens_copy[0, i])
+        return self.class.new(@path.sub_path(0, 1), tokens_copy[0, i])
       end
     end
     self

--- a/lib/hocon/impl/config_node_root.rb
+++ b/lib/hocon/impl/config_node_root.rb
@@ -1,0 +1,59 @@
+# encoding: utf-8
+
+require 'hocon/impl'
+require 'hocon/impl/config_node_array'
+require 'hocon/impl/config_node_complex_value'
+require 'hocon/impl/config_node_object'
+
+class Hocon::Impl::ConfigNodeRoot < Hocon::Impl::ConfigNodeComplexValue
+  def initialize(children, origin)
+    super(children)
+    @origin = origin
+  end
+
+  def new_node(nodes)
+    raise Hocon::ConfigError::ConfigBugOrBrokenError, "Tried to indent the root object"
+  end
+
+  def value
+    @children.each do |node|
+      if node.is_a?(Hocon::Impl::ConfigNodeComplexValue)
+        return node
+      end
+    end
+    raise Hocon::ConfigError::ConfigBugOrBrokenError, "ConfigNodeRoot did not contain a value"
+  end
+
+  def set_value(desired_path, value, flavor)
+    children_copy = @children.clone
+    children_copy.each_with_index do |node, index|
+      if node.is_a?(Hocon::Impl::ConfigNodeComplexValue)
+        if node.is_a?(Hocon::Impl::ConfigNodeArray)
+          raise Hocon::ConfigError::ConfigBugOrBrokenError, "The ConfigDocument had an array at the root level, and values cannot be modified inside an array."
+        elsif node.is_a?(Hocon::Impl::ConfigNodeObject)
+          if value.nil?
+            children_copy[index] = node.remove_value_on_path(desired_path, flavor)
+          else
+            children_copy[index] = node.set_value_on_path(desired_path, value, flavor)
+          end
+          return self.class.new(children_copy, @origin)
+        end
+      end
+    end
+    raise Hocon::ConfigError::ConfigBugOrBrokenError, "ConfigNodeRoot did not contain a value"
+  end
+
+  def has_value(desired_path)
+    path = Hocon::Impl::PathParser.parse_path(desired_path)
+    @children.each do |node|
+      if node.is_a?(Hocon::Impl::ConfigNodeComplexValue)
+        if node.is_a?(Hocon::Impl::ConfigNodeArray)
+          raise Hocon::ConfigError::ConfigBugOrBrokenError, "The ConfigDocument had an array at the root level, and values cannot be modified inside an array."
+        elsif node.is_a?(Hocon::Impl::ConfigNodeObject)
+          return node.has_value(path)
+        end
+      end
+    end
+    raise Hocon::ConfigError::ConfigBugOrBrokenError, "ConfigNodeRoot did not contain a value"
+  end
+end

--- a/lib/hocon/impl/config_node_root.rb
+++ b/lib/hocon/impl/config_node_root.rb
@@ -5,7 +5,8 @@ require 'hocon/impl/config_node_array'
 require 'hocon/impl/config_node_complex_value'
 require 'hocon/impl/config_node_object'
 
-class Hocon::Impl::ConfigNodeRoot < Hocon::Impl::ConfigNodeComplexValue
+class Hocon::Impl::ConfigNodeRoot
+  include Hocon::Impl::ConfigNodeComplexValue
   def initialize(children, origin)
     super(children)
     @origin = origin

--- a/lib/hocon/impl/config_node_simple_value.rb
+++ b/lib/hocon/impl/config_node_simple_value.rb
@@ -1,0 +1,41 @@
+# encoding: utf-8
+
+require 'hocon/config_error'
+require 'hocon/impl'
+require 'hocon/impl/abstract_config_node_value'
+require 'hocon/impl/array_iterator'
+require 'hocon/impl/config_reference'
+require 'hocon/impl/config_string'
+require 'hocon/impl/path_parser'
+require 'hocon/impl/substitution_expression'
+require 'hocon/impl/tokens'
+
+class Hocon::Impl::ConfigNodeSimpleValue < Hocon::Impl::AbstractConfigNodeValue
+
+  Tokens = Hocon::Impl::Tokens
+
+  def initialize(value)
+    @token = value
+  end
+
+  attr_reader :token
+
+  def tokens
+    [@token]
+  end
+
+  def value
+    if Tokens.value?(@token)
+      return Tokens.value(@token)
+    elsif Tokens.unquoted_text?(@token)
+      return Hocon::Impl::ConfigString::Unquoted.new(@token.origin, Tokens.unquoted_text(@token))
+    elsif Tokens.substitution?(@token)
+      expression = Tokens.get_substitution_path_expression(@token)
+      path = Hocon::Impl::PathParser.parse_path_expression(Hocon::Impl::ArrayIterator.new(expression), @token.origin)
+      optional = Tokens.get_substitution_optional(@token)
+
+      return Hocon::Impl::ConfigReference.new(@token.origin, Hocon::Impl::SubstitutionExpression.new(path, optional))
+    end
+    raise Hocon::ConfigError::ConfigBugOrBrokenError, 'ConfigNodeSimpleValue did not contain a valid value token'
+  end
+end

--- a/lib/hocon/impl/config_node_simple_value.rb
+++ b/lib/hocon/impl/config_node_simple_value.rb
@@ -10,7 +10,8 @@ require 'hocon/impl/path_parser'
 require 'hocon/impl/substitution_expression'
 require 'hocon/impl/tokens'
 
-class Hocon::Impl::ConfigNodeSimpleValue < Hocon::Impl::AbstractConfigNodeValue
+class Hocon::Impl::ConfigNodeSimpleValue
+  include Hocon::Impl::AbstractConfigNodeValue
 
   Tokens = Hocon::Impl::Tokens
 

--- a/lib/hocon/impl/config_node_single_token.rb
+++ b/lib/hocon/impl/config_node_single_token.rb
@@ -3,7 +3,8 @@
 require 'hocon/impl'
 require 'hocon/impl/abstract_config_node'
 
-class Hocon::Impl::ConfigNodeSingleToken < Hocon::Impl::AbstractConfigNode
+class Hocon::Impl::ConfigNodeSingleToken
+  include Hocon::Impl::AbstractConfigNode
   def initialize(t)
     @token = t
   end

--- a/lib/hocon/impl/config_node_single_token.rb
+++ b/lib/hocon/impl/config_node_single_token.rb
@@ -1,0 +1,16 @@
+# encoding: utf-8
+
+require 'hocon/impl'
+require 'hocon/impl/abstract_config_node'
+
+class Hocon::Impl::ConfigNodeSingleToken < Hocon::Impl::AbstractConfigNode
+  def initialize(t)
+    @token = t
+  end
+
+  attr_reader :token
+
+  def tokens
+    [@token]
+  end
+end

--- a/lib/hocon/impl/parser.rb
+++ b/lib/hocon/impl/parser.rb
@@ -310,7 +310,7 @@ class Hocon::Impl::Parser
     # IgnoredWhitespace tokens
     def next_token_ignoring_whitespace
       t = @tokens.next
-      while Tokens.ignore_whitespace?(t)
+      while Tokens.ignored_whitespace?(t)
         t = @tokens.next
       end
       t

--- a/lib/hocon/impl/path.rb
+++ b/lib/hocon/impl/path.rb
@@ -179,7 +179,7 @@ class Hocon::Impl::Path
         my_remainder = my_remainder.remainder
         other_remainder = other_remainder.remainder
       end
-      true
+      return true
     end
     false
   end

--- a/lib/hocon/impl/path_parser.rb
+++ b/lib/hocon/impl/path_parser.rb
@@ -37,7 +37,7 @@ class Hocon::Impl::PathParser
     SimpleConfigOrigin.new_simple("path parameter")
   end
 
-  def parse_path_node(path, flavor = ConfigSyntax::CONF)
+  def self.parse_path_node(path, flavor = ConfigSyntax::CONF)
     reader = StringIO.new(path)
 
     begin
@@ -95,7 +95,7 @@ class Hocon::Impl::PathParser
       end
 
       # Ignore all IgnoredWhitespace tokens
-      next if Tokens.ignore_whitespace?(t)
+      next if Tokens.ignored_whitespace?(t)
 
       if Tokens.value_with_type?(t, ConfigValueType::STRING)
         v = Tokens.value(t)

--- a/lib/hocon/impl/path_parser.rb
+++ b/lib/hocon/impl/path_parser.rb
@@ -41,10 +41,10 @@ class Hocon::Impl::PathParser
     reader = StringIO.new(path)
 
     begin
-      tokens = Tokenizer.tokenize(self.class.api_origin, reader,
+      tokens = Tokenizer.tokenize(api_origin, reader,
                                   flavor)
       tokens.next # drop START
-      parse_path_node_expression(tokens, self.class.api_origin, path, flavor)
+      parse_path_node_expression(tokens, api_origin, path, flavor)
     ensure
       reader.close
     end
@@ -164,12 +164,12 @@ class Hocon::Impl::PathParser
     pb.result
   end
 
-  def split_token_on_period(t, flavor)
+  def self.split_token_on_period(t, flavor)
     token_text = t.token_text
     if token_text == "."
       return [t]
     end
-    split_token = token_text.split('\.')
+    split_token = token_text.split('.')
     split_tokens = []
     split_token.each do |s|
       if flavor == ConfigSyntax::CONF
@@ -179,8 +179,8 @@ class Hocon::Impl::PathParser
       end
       split_tokens << Tokens.new_unquoted_text(t.origin, ".")
     end
-    if token_text[token_text - 1] != "."
-      split_tokens.remove(split_tokens.size - 1)
+    if token_text[-1] != "."
+      split_tokens.delete_at(split_tokens.size - 1)
     end
     split_tokens
   end

--- a/lib/hocon/impl/tokens.rb
+++ b/lib/hocon/impl/tokens.rb
@@ -366,7 +366,7 @@ class Hocon::Impl::Tokens
     end
   end
 
-  def self.ignore_whitespace?(token)
+  def self.ignored_whitespace?(token)
     token.is_a?(IgnoredWhitespace)
   end
 

--- a/lib/hocon/parser.rb
+++ b/lib/hocon/parser.rb
@@ -1,0 +1,7 @@
+# encoding: utf-8
+
+require 'hocon'
+
+module Hocon::Parser
+
+end

--- a/lib/hocon/parser/config_node.rb
+++ b/lib/hocon/parser/config_node.rb
@@ -19,7 +19,7 @@ require 'hocon/config_error'
 # implementations will break.
 #
 
-class Hocon::Parser::ConfigNode
+module Hocon::Parser::ConfigNode
   #
   # The original text of the input which was used to form this particular node.
   # @return the original text used to form this node as a String

--- a/lib/hocon/parser/config_node.rb
+++ b/lib/hocon/parser/config_node.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-require 'hocon'
+require 'hocon/parser'
 require 'hocon/config_error'
 
 #
@@ -19,7 +19,7 @@ require 'hocon/config_error'
 # implementations will break.
 #
 
-class Hocon::ConfigNode
+class Hocon::Parser::ConfigNode
   #
   # The original text of the input which was used to form this particular node.
   # @return the original text used to form this node as a String

--- a/spec/test_utils.rb
+++ b/spec/test_utils.rb
@@ -7,6 +7,11 @@ require 'hocon/impl/config_reference'
 require 'hocon/impl/substitution_expression'
 require 'hocon/impl/path_parser'
 require 'hocon/impl/config_impl_util'
+require 'hocon/impl/config_node_simple_value'
+require 'hocon/impl/config_node_single_token'
+require 'hocon/impl/config_node_object'
+require 'hocon/impl/config_node_array'
+require 'hocon/impl/config_node_concatenation'
 
 module TestUtils
   Tokens = Hocon::Impl::Tokens
@@ -361,6 +366,119 @@ module TestUtils
     Hocon::Impl::Tokenizer.render(tokenize_from_s(input_string))
   end
 
+  def self.config_node_simple_value(value)
+    Hocon::Impl::ConfigNodeSimpleValue.new(value)
+  end
+
+  def self.config_node_key(path)
+    Hocon::Impl::PathParser.parse_path_node(path)
+  end
+
+  def self.config_node_single_token(value)
+    Hocon::Impl::ConfigNodeSingleToken.new(value)
+  end
+
+  def self.config_node_object(nodes)
+    Hocon::Impl::ConfigNodeObject.new(nodes)
+  end
+
+  def self.config_node_array(nodes)
+    Hocon::Impl::ConfigNodeArray.new(nodes)
+  end
+
+  def self.config_node_concatenation(nodes)
+    Hocon::Impl::ConfigNodeConcatenation.new(nodes)
+  end
+
+  def self.node_colon
+    Hocon::Impl::ConfigNodeSingleToken.new(Tokens::COLON)
+  end
+
+  def self.node_space
+    Hocon::Impl::ConfigNodeSingleToken.new(token_unquoted(" "))
+  end
+
+  def self.node_open_brace
+    Hocon::Impl::ConfigNodeSingleToken.new(Tokens::OPEN_CURLY)
+  end
+
+  def self.node_close_brace
+    Hocon::Impl::ConfigNodeSingleToken.new(Tokens::CLOSE_CURLY)
+  end
+
+  def self.node_open_bracket
+    Hocon::Impl::ConfigNodeSingleToken.new(Tokens::OPEN_SQUARE)
+  end
+
+  def self.node_close_bracket
+    Hocon::Impl::ConfigNodeSingleToken.new(Tokens::CLOSE_SQUARE)
+  end
+
+  def self.node_comma
+    Hocon::Impl::ConfigNodeSingleToken.new(Tokens::COMMA)
+  end
+
+  def self.node_line(line)
+    Hocon::Impl::ConfigNodeSingleToken.new(token_line(line))
+  end
+
+  def self.node_whitespace(whitespace)
+    Hocon::Impl::ConfigNodeSingleToken.new(token_whitespace(whitespace))
+  end
+
+  def self.node_key_value_pair(key, value)
+    nodes = [key, node_space, node_colon, node_space, value]
+    Hocon::Impl::ConfigNodeField.new(nodes)
+  end
+
+  def self.node_int(value)
+    Hocon::Impl::ConfigNodeSimpleValue.new(token_int(value))
+  end
+
+  def self.node_string(value)
+    Hocon::Impl::ConfigNodeSimpleValue.new(token_string(value))
+  end
+
+  def self.node_double(value)
+    Hocon::Impl::ConfigNodeSimpleValue.new(token_double(value))
+  end
+
+  def self.node_true
+    Hocon::Impl::ConfigNodeSimpleValue.new(token_true)
+  end
+
+  def self.node_false
+    Hocon::Impl::ConfigNodeSimpleValue.new(token_false)
+  end
+
+  def self.node_comment_hash(text)
+    Hocon::Impl::ConfigNodeComment.new(token_comment_hash(text))
+  end
+
+  def self.node_comment_double_slash(text)
+    Hocon::Impl::ConfigNodeComment.new(token_comment_double_slash(text))
+  end
+
+  def self.node_unquoted_text(text)
+    Hocon::Impl::ConfigNodeSimpleValue.new(token_unquoted(text))
+  end
+
+  def self.node_null
+    Hocon::Impl::ConfigNodeSimpleValue.new(token_null)
+  end
+
+  def self.node_key_substitution(s)
+    Hocon::Impl::ConfigNodeSimpleValue.new(token_key_substitution(s))
+  end
+
+  def self.node_optional_substitution(*expression)
+    Hocon::Impl::ConfigNodeSimpleValue.new(token_optional_substitution(*expression))
+  end
+
+  def self.node_substitution(*expression)
+    Hocon::Impl::ConfigNodeSimpleValue.new(token_substitution(*expression))
+  end
+
   def self.fake_origin
     Hocon::Impl::SimpleConfigOrigin.new_simple("fake origin")
   end
@@ -398,15 +516,15 @@ module TestUtils
   end
 
   def self.token_string(value)
-    Tokens.new_string(fake_origin, value, value)
+    Tokens.new_string(fake_origin, value, "\"#{value}\"")
   end
 
   def self.token_double(value)
-    Tokens.new_double(fake_origin, value, nil)
+    Tokens.new_double(fake_origin, value, "#{value}")
   end
 
   def self.token_int(value)
-    Tokens.new_int(fake_origin, value, nil)
+    Tokens.new_int(fake_origin, value, "#{value}")
   end
 
   def self.token_maybe_optional_substitution(optional, token_list)

--- a/spec/unit/typesafe/config/concatenation_spec.rb
+++ b/spec/unit/typesafe/config/concatenation_spec.rb
@@ -359,12 +359,12 @@ describe "concatenation" do
 
   it "concat two undefined substitutions" do
     conf = TestUtils.parse_config("a = ${?foo}${?bar}").resolve
-    expect(conf.has_path?("a")).to be_false
+    expect(conf.has_path?("a")).to be_falsey
   end
 
   it "concat several undefined substitutions" do
     conf = TestUtils.parse_config("a = ${?foo}${?bar}${?baz}${?woooo}").resolve
-    expect(conf.has_path?("a")).to be_false
+    expect(conf.has_path?("a")).to be_falsey
   end
 
   it "concat two undefined substitutions with a space" do

--- a/spec/unit/typesafe/config/config_node_spec.rb
+++ b/spec/unit/typesafe/config/config_node_spec.rb
@@ -1,0 +1,552 @@
+# encoding: utf-8
+
+require 'spec_helper'
+require 'hocon'
+require 'test_utils'
+
+describe Hocon::Parser::ConfigNode do
+  Tokens = Hocon::Impl::Tokens
+
+  shared_examples_for "single token node test" do
+    it "should render the node with the text of the token" do
+      node = TestUtils.config_node_single_token(token)
+      expect(node.render).to eq(token.token_text)
+    end
+  end
+
+  shared_examples_for "key node test" do
+    it "should render the node with the text of the path" do
+      node = TestUtils.config_node_key(path)
+      expect(path).to eq(node.render)
+    end
+  end
+
+  shared_examples_for "simple value node test" do
+    it "should render the original token text" do
+      node = TestUtils.config_node_simple_value(token)
+      expect(node.render).to eq(token.token_text)
+    end
+  end
+
+  shared_examples_for "field node test" do
+    it "should properly replace the value of a field node" do
+      key_val_node = TestUtils.node_key_value_pair(key, value)
+      expect(key_val_node.render).to eq("#{key.render} : #{value.render}")
+      expect(key_val_node.path.render).to eq(key.render)
+      expect(key_val_node.value.render).to eq(value.render)
+
+      new_key_val_node = key_val_node.replace_value(new_value)
+      expect(new_key_val_node.render).to eq("#{key.render} : #{new_value.render}")
+      expect(new_key_val_node.value.render).to eq(new_value.render)
+    end
+  end
+
+  shared_examples_for "top level value replace test" do
+    it "should replace a value in a ConfigNodeObject" do
+      complex_node_children = [TestUtils.node_open_brace,
+                               TestUtils.node_key_value_pair(TestUtils.config_node_key(key), value),
+                               TestUtils.node_close_brace]
+      complex_node = TestUtils.config_node_object(complex_node_children)
+      new_node = complex_node.set_value_on_path(key, new_value)
+      orig_text = "{#{key} : #{value.render}}"
+      final_text = "{#{key} : #{new_value.render}}"
+
+      expect(complex_node.render).to eq(orig_text)
+      expect(new_node.render).to eq(final_text)
+    end
+  end
+
+  shared_examples_for "replace duplicates test" do
+    it "should remove duplicates of a key when setting a value" do
+      key = TestUtils.config_node_key('foo')
+      key_val_pair_1 = TestUtils.node_key_value_pair(key, value1)
+      key_val_pair_2 = TestUtils.node_key_value_pair(key, value2)
+      key_val_pair_3 = TestUtils.node_key_value_pair(key, value3)
+      complex_node = TestUtils.config_node_object([key_val_pair_1, key_val_pair_2, key_val_pair_3])
+      orig_text = "#{key_val_pair_1.render}#{key_val_pair_2.render}#{key_val_pair_3.render}"
+      final_text = "#{key.render} : 15"
+
+      expect(complex_node.render).to eq(orig_text)
+      expect(complex_node.set_value_on_path("foo", TestUtils.node_int(15)).render).to eq(final_text)
+    end
+  end
+
+  shared_examples_for "non existent path test" do
+    it "should properly add a key/value pair if the key does not exist in the object" do
+      node = TestUtils.config_node_object([TestUtils.node_key_value_pair(TestUtils.config_node_key("bar"), TestUtils.node_int(15))])
+      expect(node.render).to eq('bar : 15')
+      new_node = node.set_value_on_path('foo', value)
+      final_text = "bar : 15, foo : #{value.render}"
+      expect(new_node.render).to eq(final_text)
+    end
+  end
+
+  ########################
+  # ConfigNodeSingleToken
+  ########################
+  context "create basic config node" do
+    # Ensure a ConfigNodeSingleToken can handle all its required token types
+    context "start of file" do
+      let(:token) { Tokens::START }
+      include_examples "single token node test"
+    end
+
+    context "end of file" do
+      let(:token) { Tokens::EOF }
+      include_examples "single token node test"
+    end
+
+    context "{" do
+      let (:token) { Tokens::OPEN_CURLY }
+      include_examples "single token node test"
+    end
+
+    context "}" do
+      let (:token) { Tokens::CLOSE_CURLY }
+      include_examples "single token node test"
+    end
+
+    context "[" do
+      let (:token) { Tokens::OPEN_SQUARE }
+      include_examples "single token node test"
+    end
+
+    context "]" do
+      let (:token) { Tokens::CLOSE_SQUARE }
+      include_examples "single token node test"
+    end
+
+    context "," do
+      let (:token) { Tokens::COMMA }
+      include_examples "single token node test"
+    end
+
+    context "=" do
+      let (:token) { Tokens::EQUALS }
+      include_examples "single token node test"
+    end
+
+    context ":" do
+      let (:token) { Tokens::COLON }
+      include_examples "single token node test"
+    end
+
+    context "+=" do
+      let (:token) { Tokens::PLUS_EQUALS }
+      include_examples "single token node test"
+    end
+
+    context "unquoted text" do
+      let (:token) { TestUtils.token_unquoted('             ') }
+      include_examples "single token node test"
+    end
+
+    context "ignored whitespace" do
+      let (:token) { TestUtils.token_whitespace('             ') }
+      include_examples "single token node test"
+    end
+
+    context '\n' do
+      let (:token) { TestUtils.token_line(1) }
+      include_examples "single token node test"
+    end
+
+    context "double slash comment" do
+      let (:token) { TestUtils.token_comment_double_slash(" this is a double slash comment  ") }
+      include_examples "single token node test"
+    end
+
+    context "hash comment" do
+      let (:token) { TestUtils.token_comment_hash(" this is a hash comment  ") }
+      include_examples "single token node test"
+    end
+  end
+
+  ####################
+  # ConfigNodeSetting
+  ####################
+  context "create config node setting" do
+    # Ensure a ConfigNodeSetting can handle the normal key types
+    context "unquoted key" do
+      let (:path) { "foo" }
+      include_examples "key node test"
+    end
+
+    context "quoted_key" do
+      let (:path) { "\"Hello I am a key how are you today\"" }
+      include_examples "key node test"
+    end
+  end
+
+  context "path node subpath" do
+    it "should produce correct subpaths of path nodes with subpath method" do
+      orig_path = 'a.b.c."@$%#@!@#$"."".1234.5678'
+      path_node = TestUtils.config_node_key(orig_path)
+
+      expect(path_node.render).to eq(orig_path)
+      expect(path_node.sub_path(2).render).to eq('c."@$%#@!@#$"."".1234.5678')
+      expect(path_node.sub_path(6).render).to eq('5678')
+    end
+  end
+
+  ########################
+  # ConfigNodeSimpleValue
+  ########################
+  context "create config node simple value" do
+    context "integer" do
+      let (:token) { TestUtils.token_int(10) }
+      include_examples "simple value node test"
+    end
+
+    context "double" do
+      let (:token) { TestUtils.token_double(3.14159) }
+      include_examples "simple value node test"
+    end
+
+    context "false" do
+      let (:token) { TestUtils.token_false }
+      include_examples "simple value node test"
+    end
+
+    context "true" do
+      let (:token) { TestUtils.token_true }
+      include_examples "simple value node test"
+    end
+
+    context "null" do
+      let (:token) { TestUtils.token_null }
+      include_examples "simple value node test"
+    end
+
+    context "quoted text" do
+      let (:token) { TestUtils.token_string("Hello my name is string") }
+      include_examples "simple value node test"
+    end
+
+    context "unquoted text" do
+      let (:token) { TestUtils.token_unquoted("mynameisunquotedstring") }
+      include_examples "simple value node test"
+    end
+
+    context "key substitution" do
+      let (:token) { TestUtils.token_key_substitution("c.d") }
+      include_examples "simple value node test"
+    end
+
+    context "optional substitution" do
+      let (:token) { TestUtils.token_optional_substitution(TestUtils.token_unquoted("x.y")) }
+      include_examples "simple value node test"
+    end
+
+    context "substitution" do
+      let (:token) { TestUtils.token_substitution(TestUtils.token_unquoted("a.b")) }
+      include_examples "simple value node test"
+    end
+  end
+
+  ####################
+  # ConfigNodeField
+  ####################
+  context "create ConfigNodeField" do
+    let (:key) { TestUtils.config_node_key('"abc"') }
+    let (:value) { TestUtils.node_int(123) }
+
+    context "supports quoted keys" do
+      let (:new_value) { TestUtils.node_int(245) }
+      include_examples "field node test"
+    end
+
+    context "supports unquoted keys" do
+      let (:key) { TestUtils.config_node_key('abc') }
+      let (:new_value) { TestUtils.node_int(245) }
+      include_examples "field node test"
+    end
+
+    context "can replace a simple value with a different type of simple value" do
+      let (:new_value) { TestUtils.node_string('I am a string') }
+      include_examples "field node test"
+    end
+
+    context "can replace a simple value with a complex value" do
+      let (:new_value) { TestUtils.config_node_object([TestUtils.node_open_brace, TestUtils.node_close_brace]) }
+      include_examples "field node test"
+    end
+  end
+
+  ####################
+  # Node Replacement
+  ####################
+  context "replace nodes" do
+    let (:key) { "foo" }
+    array = TestUtils.config_node_array([TestUtils.node_open_bracket, TestUtils.node_int(10), TestUtils.node_space, TestUtils.node_comma,
+                                         TestUtils.node_space, TestUtils.node_int(15), TestUtils.node_close_bracket])
+    nested_map = TestUtils.config_node_object([TestUtils.node_open_brace,
+                                               TestUtils.node_key_value_pair(TestUtils.config_node_key("abc"),
+                                                                             TestUtils.config_node_simple_value(TestUtils.token_string("a string"))),
+                                               TestUtils.node_close_brace])
+
+    context "replace an integer with an integer" do
+      let (:value) { TestUtils.node_int(10) }
+      let (:new_value) { TestUtils.node_int(15) }
+      include_examples "top level value replace test"
+    end
+
+    context "replace a double with an integer" do
+      let (:value) { TestUtils.node_double(3.14159) }
+      let (:new_value) { TestUtils.node_int(10000) }
+      include_examples "top level value replace test"
+    end
+
+    context "replace false with true" do
+      let (:value) { TestUtils.node_false }
+      let (:new_value) { TestUtils.node_true }
+      include_examples "top level value replace test"
+    end
+
+    context "replace true with null" do
+      let (:value) { TestUtils.node_true }
+      let (:new_value) { TestUtils.node_null }
+      include_examples "top level value replace test"
+    end
+
+    context "replace null with a string" do
+      let (:value) { TestUtils.node_null }
+      let (:new_value) { TestUtils.node_string("Hello my name is string") }
+      include_examples "top level value replace test"
+    end
+
+    context "replace a string with unquoted text" do
+      let (:value) { TestUtils.node_string("Hello my name is string") }
+      let (:new_value) { TestUtils.node_unquoted_text("mynameisunquotedstring") }
+      include_examples "top level value replace test"
+    end
+
+    context "replace unquoted text with a key substitution" do
+      let (:value) { TestUtils.node_unquoted_text("mynameisunquotedstring") }
+      let (:new_value) { TestUtils.node_key_substitution("c.d") }
+      include_examples "top level value replace test"
+    end
+
+    context "replace int with an optional substitution" do
+      let (:value) { TestUtils.node_int(10) }
+      let (:new_value) { TestUtils.node_optional_substitution(TestUtils.token_unquoted("x.y")) }
+      include_examples "top level value replace test"
+    end
+
+    context "replace int with a substitution" do
+      let (:value) { TestUtils.node_int(10) }
+      let (:new_value) { TestUtils.node_substitution(TestUtils.token_unquoted("a.b")) }
+      include_examples "top level value replace test"
+    end
+
+    context "replace substitution with an int" do
+      let (:value) { TestUtils.node_substitution(TestUtils.token_unquoted("a.b")) }
+      let (:new_value) { TestUtils.node_int(10) }
+      include_examples "top level value replace test"
+    end
+
+    context "ensure arrays can be replaced" do
+      context "can replace a simple value with an array" do
+        let (:value) { TestUtils.node_int(10) }
+        let (:new_value) { array }
+        include_examples "top level value replace test"
+      end
+
+      context "can replace an array with a simple value" do
+        let (:value) { array }
+        let (:new_value) { TestUtils.node_int(10) }
+        include_examples "top level value replace test"
+      end
+
+      context "can replace an array with another complex value" do
+        let (:value) { array }
+        let (:new_value) { TestUtils.config_node_object([TestUtils.node_open_brace, TestUtils.node_close_brace])}
+        include_examples "top level value replace test"
+      end
+    end
+
+    context "ensure objects can be replaced" do
+      context "can replace an object with a simple value" do
+        let (:value) { nested_map }
+        let (:new_value) { TestUtils.node_int(10) }
+        include_examples "top level value replace test"
+      end
+
+      context "can replace a simple value with an object" do
+        let (:value) { TestUtils.node_int(10) }
+        let (:new_value) { nested_map }
+        include_examples "top level value replace test"
+      end
+
+      context "can replace an array with an object" do
+        let (:value) { array }
+        let (:new_value) { nested_map }
+        include_examples "top level value replace test"
+      end
+
+      context "can replace an object with an array" do
+        let (:value) { nested_map }
+        let (:new_value) { array }
+        include_examples "top level value replace test"
+      end
+
+      context "can replace an object with an empty object" do
+        let (:value) { nested_map }
+        let (:new_value) { TestUtils.config_node_object([TestUtils.node_open_brace, TestUtils.node_close_brace]) }
+        include_examples "top level value replace test"
+      end
+    end
+
+    context "ensure concatenations can be replaced" do
+      concatenation = TestUtils.config_node_concatenation([TestUtils.node_int(10), TestUtils.node_space, TestUtils.node_string("Hello")])
+
+      context "can replace a concatenation with a simple value" do
+        let (:value) { concatenation }
+        let (:new_value) { TestUtils.node_int(12) }
+        include_examples "top level value replace test"
+      end
+
+      context "can replace a simple value with a concatenation" do
+        let (:value) { TestUtils.node_int(12) }
+        let (:new_value) { concatenation }
+        include_examples "top level value replace test"
+      end
+
+      context "can replace an object with a concatenation" do
+        let (:value) { nested_map }
+        let (:new_value) { concatenation }
+        include_examples "top level value replace test"
+      end
+
+      context "can replace a concatenation with an object" do
+        let (:value) { concatenation }
+        let (:new_value) { nested_map }
+        include_examples "top level value replace test"
+      end
+
+      context "can replace an array with a concatenation" do
+        let (:value) { array }
+        let (:new_value) { concatenation }
+        include_examples "top level value replace test"
+      end
+
+      context "can replace a concatenation with an array" do
+        let (:value) { concatenation }
+        let (:new_value) { array }
+        include_examples "top level value replace test"
+      end
+    end
+
+    context 'ensure a key with format "a.b" will be properly replaced' do
+      let (:key) { 'foo.bar' }
+      let (:value) { TestUtils.node_int(10) }
+      let (:new_value) { nested_map }
+      include_examples "top level value replace test"
+    end
+  end
+
+  ####################
+  # Duplicate Removal
+  ####################
+  context "remove duplicates" do
+    empty_map_node = TestUtils.config_node_object([TestUtils.node_open_brace, TestUtils.node_close_brace])
+    empty_array_node = TestUtils.config_node_array([TestUtils.node_open_bracket, TestUtils.node_close_bracket])
+
+    context "duplicates containing simple values will all be removed" do
+      let (:value1) { TestUtils.node_int(10) }
+      let (:value2) { TestUtils.node_true }
+      let (:value3) { TestUtils.node_null }
+      include_examples "replace duplicates test"
+    end
+
+    context "duplicates containing objects will be removed" do
+      let (:value1) { empty_map_node }
+      let (:value2) { empty_map_node }
+      let (:value3) { empty_map_node }
+      include_examples "replace duplicates test"
+    end
+
+    context "duplicates containing arrays will be removed" do
+      let (:value1) { empty_array_node }
+      let (:value2) { empty_array_node }
+      let (:value3) { empty_array_node }
+      include_examples "replace duplicates test"
+    end
+
+    context "duplicates containing a mix of value types will be removed" do
+      let (:value1) { TestUtils.node_int(10) }
+      let (:value2) { empty_map_node }
+      let (:value3) { empty_array_node }
+      include_examples "replace duplicates test"
+    end
+  end
+
+  #################################
+  # Addition of non-existent paths
+  #################################
+  context "add non existent paths" do
+    context "adding an integer" do
+      let (:value) { TestUtils.node_int(10) }
+      include_examples "non existent path test"
+    end
+
+    context "adding an array" do
+      let (:value) { TestUtils.config_node_array([TestUtils.node_open_bracket, TestUtils.node_int(15), TestUtils.node_close_bracket]) }
+      include_examples "non existent path test"
+    end
+
+    context "adding an object" do
+      let (:value) { TestUtils.config_node_object([TestUtils.node_open_brace,
+                                                   TestUtils.node_key_value_pair(TestUtils.config_node_key('foo'),
+                                                                                 TestUtils.node_double(3.14)),
+                                                   TestUtils.node_close_brace]) }
+      include_examples "non existent path test"
+    end
+  end
+
+  #################################
+  # Replacement of nested nodes
+  #################################
+  context "replace nested nodes" do
+    orig_text = "foo : bar\nbaz : {\n\t\"abc.def\" : 123\n\t//This is a comment about the below setting\n\n\tabc : {\n\t\t" +
+        "def : \"this is a string\"\n\t\tghi : ${\"a.b\"}\n\t}\n}\nbaz.abc.ghi : 52\nbaz.abc.ghi : 53\n}"
+    lowest_level_map = TestUtils.config_node_object([TestUtils.node_open_brace, TestUtils.node_line(6), TestUtils.node_whitespace("\t\t"),
+                                                     TestUtils.node_key_value_pair(TestUtils.config_node_key("def"), TestUtils.config_node_simple_value(TestUtils.token_string("this is a string"))),
+                                                     TestUtils.node_line(7), TestUtils.node_whitespace("\t\t"),
+                                                     TestUtils.node_key_value_pair(TestUtils.config_node_key("ghi"), TestUtils.config_node_simple_value(TestUtils.token_key_substitution("a.b"))),
+                                                     TestUtils.node_line(8), TestUtils.node_whitespace("\t"), TestUtils.node_close_brace])
+    higher_level_map = TestUtils.config_node_object([TestUtils.node_open_brace, TestUtils.node_line(2), TestUtils.node_whitespace("\t"),
+                                                     TestUtils.node_key_value_pair(TestUtils.config_node_key('"abc.def"'), TestUtils.config_node_simple_value(TestUtils.token_int(123))),
+                                                     TestUtils.node_line(3), TestUtils.node_whitespace("\t"), TestUtils.node_comment_double_slash("This is a comment about the below setting"),
+                                                     TestUtils.node_line(4), TestUtils.node_line(5), TestUtils.node_whitespace("\t"),
+                                                     TestUtils.node_key_value_pair(TestUtils.config_node_key("abc"), lowest_level_map), TestUtils.node_line(9), TestUtils.node_close_brace])
+    orig_node = TestUtils.config_node_object([TestUtils.node_key_value_pair(TestUtils.config_node_key("foo"), TestUtils.config_node_simple_value(TestUtils.token_unquoted("bar"))),
+                                              TestUtils.node_line(1), TestUtils.node_key_value_pair(TestUtils.config_node_key('baz'), higher_level_map), TestUtils.node_line(10),
+                                              TestUtils.node_key_value_pair(TestUtils.config_node_key('baz.abc.ghi'), TestUtils.config_node_simple_value(TestUtils.token_int(52))),
+                                              TestUtils.node_line(11),
+                                              TestUtils.node_key_value_pair(TestUtils.config_node_key('baz.abc.ghi'), TestUtils.config_node_simple_value(TestUtils.token_int(53))),
+                                              TestUtils.node_line(12), TestUtils.node_close_brace])
+    it "should properly render the original node" do
+      expect(orig_node.render).to eq(orig_text)
+    end
+
+    it "should properly replae values in the original node" do
+      final_text = "foo : bar\nbaz : {\n\t\"abc.def\" : true\n\t//This is a comment about the below setting\n\n\tabc : {\n\t\t" +
+          "def : false\n\t\t\n\t\t\"this.does.not.exist@@@+$#\" : { end : doesnotexist }\n\t}\n}\n\nbaz.abc.ghi : randomunquotedString\n}"
+
+      # Paths with quotes in the name are treated as a single Path, rather than multiple sub-paths
+      new_node = orig_node.set_value_on_path('baz."abc.def"', TestUtils.config_node_simple_value(TestUtils.token_true))
+      new_node = new_node.set_value_on_path('baz.abc.def', TestUtils.config_node_simple_value(TestUtils.token_false))
+
+      # Repeats are removed from nested maps
+      new_node = new_node.set_value_on_path('baz.abc.ghi', TestUtils.config_node_simple_value(TestUtils.token_unquoted('randomunquotedString')))
+
+      # Missing paths are added to the top level if they don't appear anywhere, including in nested maps
+      new_node = new_node.set_value_on_path('baz.abc."this.does.not.exist@@@+$#".end', TestUtils.config_node_simple_value(TestUtils.token_unquoted('doesnotexist')))
+
+      # The above operations cause the resultant map to be rendered properly
+      expect(new_node.render).to eq(final_text)
+    end
+  end
+
+end


### PR DESCRIPTION
Some of the implementation of this is a bit different from what's in master at the time of this writing. This is due to the fact that, when porting these tests, I discovered some issues with the upstream tests that needed to be fixed/cleaned up. This PR contains the tests in the upstream master branch, along with the changes I've made in https://github.com/typesafehub/config/pull/301.