### PR TITLE
(MAINT) Add empty document insertion test

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    hocon (0.0.7)
+    hocon (0.1.0)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/hocon/impl/simple_config_document.rb
+++ b/lib/hocon/impl/simple_config_document.rb
@@ -23,7 +23,7 @@ class Hocon::Impl::SimpleConfigDocument
   end
 
   def set_config_value(path, new_value)
-    set_value(path, new_value.render)
+    set_value(path, new_value.render.strip)
   end
 
   def remove_value(path)

--- a/spec/unit/typesafe/config/config_document_spec.rb
+++ b/spec/unit/typesafe/config/config_document_spec.rb
@@ -533,4 +533,12 @@ describe "ConfigDocument" do
       expect(config_document.set_value("c", "d").render).to eq("a : b\n      include \"foo\"\n      c : d\n")
     end
   end
+
+  context "insertion into an empty document" do
+    it "should successfully insert a value into an empty document" do
+      orig_text = ""
+      config_document = ConfigDocumentFactory.parse_string(orig_text)
+      expect(config_document.set_value("a", "1").render).to eq(" a : 1")
+    end
+  end
 end

--- a/spec/unit/typesafe/config/config_document_spec.rb
+++ b/spec/unit/typesafe/config/config_document_spec.rb
@@ -541,4 +541,14 @@ describe "ConfigDocument" do
       expect(config_document.set_value("a", "1").render).to eq(" a : 1")
     end
   end
+
+  context "can insert a map parsed with ConfigValueFactory" do
+    it "should successfully insert a map into a document" do
+      orig_text = "{ a : b }"
+      config_document = ConfigDocumentFactory.parse_string(orig_text)
+
+      map = ConfigValueFactory.from_any_ref({"a" => 1, "b" => 2})
+      expect(config_document.set_config_value("a", map).render).to eq("{ a : {\n     # hardcoded value\n     \"a\" : 1,\n     # hardcoded value\n     \"b\" : 2\n } }")
+    end
+  end
 end


### PR DESCRIPTION
Add a test for insertion into an empty ConfigDocument.

I decided to add this because it's a valid use case (we're using it in the hocon module) and because it's broken in the upstream