### PR TITLE
(MAINT) Improve error messages for Problem tokens

### DIFF
--- a/lib/hocon/impl/tokens.rb
+++ b/lib/hocon/impl/tokens.rb
@@ -166,7 +166,7 @@ class Hocon::Impl::Tokens
       sb << " ("
       sb << message
       sb << ")"
-      sb.to_s
+      sb.string
     end
 
     def can_equal(other)


### PR DESCRIPTION
Prior to this commit, the `Problem` token type called
`to_s` on an internal `StringIO` object when building
up an error string to return to the user.  Calling
`to_s` on a `StringIO` just causes it to print out,
basically, `#<StringIO...>`, so you don't get the
useful error message.

This patch changes the code to call `string` instead,
which returns a much more useful error message.