### PR TITLE
(TK-246) Fix single-line config bug

### DIFF
--- a/spec/unit/typesafe/config/config_document_spec.rb
+++ b/spec/unit/typesafe/config/config_document_spec.rb
@@ -219,7 +219,7 @@ describe "ConfigDocument" do
 
   context "config document set new value multi level CONF" do
     let (:orig_text) { "a:b\nc:d" }
-    let (:final_text) { "a:b\nc:d\ne : { f : { g : 12 } }" }
+    let (:final_text) { "a:b\nc:d\ne : {\n  f : {\n    g : 12\n  }\n}" }
     let (:new_value) { "12" }
     let (:replace_path) { "e.f.g" }
 
@@ -228,7 +228,7 @@ describe "ConfigDocument" do
 
   context "config document set new value multi level JSON" do
     let (:orig_text) { "{\"a\":\"b\",\n\"c\":\"d\"}" }
-    let (:final_text) { "{\"a\":\"b\",\n\"c\":\"d\",\n\"e\" : { \"f\" : { \"g\" : 12 } }}" }
+    let (:final_text) { "{\"a\":\"b\",\n\"c\":\"d\",\n  \"e\" : {\n    \"f\" : {\n      \"g\" : 12\n    }\n  }}" }
     let (:new_value) { "12" }
     let (:replace_path) { "e.f.g" }
 
@@ -426,7 +426,7 @@ describe "ConfigDocument" do
       end
 
       it "should properly add/indent any necessary objects along the way to the value" do
-        expect(config_document.set_value("a.d.e.f", "g").render).to eq("a {\n  b: c\n  d : { e : { f : g } }\n}")
+        expect(config_document.set_value("a.d.e.f", "g").render).to eq("a {\n  b: c\n  d : {\n    e : {\n      f : g\n    }\n  }\n}")
       end
     end
 
@@ -439,7 +439,7 @@ describe "ConfigDocument" do
       end
 
       it "should properly add/indent any necessary objects along the way to the value" do
-        expect(config_document.set_value("d.e.f", "g").render).to eq("a {\n b: c\n}\nd : { e : { f : g } }\n")
+        expect(config_document.set_value("d.e.f", "g").render).to eq("a {\n b: c\n}\nd : {\n  e : {\n    f : g\n  }\n}\n")
       end
     end
   end
@@ -538,7 +538,13 @@ describe "ConfigDocument" do
     it "should successfully insert a value into an empty document" do
       orig_text = ""
       config_document = ConfigDocumentFactory.parse_string(orig_text)
-      expect(config_document.set_value("a", "1").render).to eq(" a : 1")
+      expect(config_document.set_value("a", "1").render).to eq("a : 1")
+    end
+
+    it "should successfully insert a multi-line object into an empty document" do
+      orig_text = ""
+      config_document = ConfigDocumentFactory.parse_string(orig_text)
+      expect(config_document.set_value("a.b", "1").render).to eq("a : {\n  b : 1\n}")
     end
   end
 

--- a/spec/unit/typesafe/config/config_node_spec.rb
+++ b/spec/unit/typesafe/config/config_node_spec.rb
@@ -532,7 +532,7 @@ describe Hocon::Parser::ConfigNode do
 
     it "should properly replae values in the original node" do
       final_text = "foo : bar\nbaz : {\n\t\"abc.def\" : true\n\t//This is a comment about the below setting\n\n\tabc : {\n\t\t" +
-          "def : false\n\t\t\n\t\t\"this.does.not.exist@@@+$#\" : { end : doesnotexist }\n\t}\n}\n\nbaz.abc.ghi : randomunquotedString\n}"
+          "def : false\n\t\t\n\t\t\"this.does.not.exist@@@+$#\" : {\n\t\t  end : doesnotexist\n\t\t}\n\t}\n}\n\nbaz.abc.ghi : randomunquotedString\n}"
 
       # Paths with quotes in the name are treated as a single Path, rather than multiple sub-paths
       new_node = orig_node.set_value_on_path('baz."abc.def"', TestUtils.config_node_simple_value(TestUtils.token_true))


### PR DESCRIPTION
Previously there was a bug wherein building out a config starting
from an empty ConfigDocument would cause the entire config to
exist on a single line. Fix this bug by modifying the addition of
new maps along a path to add multi-line maps instead of
single-line maps if the object being added to is an empty root or
a multi-line object.

This PR is based on https://github.com/typesafehub/config/pull/333.