### PR TITLE
(TK-249) Remove unnecessary comments in output

### DIFF
--- a/lib/hocon/impl/simple_config_document.rb
+++ b/lib/hocon/impl/simple_config_document.rb
@@ -3,6 +3,7 @@
 require 'hocon/impl'
 require 'hocon/parser/config_document'
 require 'hocon/impl/config_document_parser'
+require 'hocon/config_render_options'
 
 class Hocon::Impl::SimpleConfigDocument
   include Hocon::Parser::ConfigDocument
@@ -23,7 +24,9 @@ class Hocon::Impl::SimpleConfigDocument
   end
 
   def set_config_value(path, new_value)
-    set_value(path, new_value.render.strip)
+    options = Hocon::ConfigRenderOptions.defaults
+    options.origin_comments = false
+    set_value(path, new_value.render(options).strip)
   end
 
   def remove_value(path)

--- a/spec/unit/typesafe/config/config_document_spec.rb
+++ b/spec/unit/typesafe/config/config_document_spec.rb
@@ -552,7 +552,7 @@ describe "ConfigDocument" do
       config_document = ConfigDocumentFactory.parse_string(orig_text)
       map_val = ConfigValueFactory.from_any_ref({"a" => 1, "b" => 2})
 
-      expect(config_document.set_config_value("a", map_val).render).to eq("a : {\n    # hardcoded value\n    \"a\" : 1,\n    # hardcoded value\n    \"b\" : 2\n}")
+      expect(config_document.set_config_value("a", map_val).render).to eq("a : {\n    \"a\" : 1,\n    \"b\" : 2\n}")
     end
 
     it "should successfully insert an array into an empty document" do
@@ -560,7 +560,7 @@ describe "ConfigDocument" do
       config_document = ConfigDocumentFactory.parse_string(orig_text)
       array_val = ConfigValueFactory.from_any_ref([1,2])
 
-      expect(config_document.set_config_value("a", array_val).render).to eq("a : [\n    # hardcoded value\n    1,\n    # hardcoded value\n    2\n]")
+      expect(config_document.set_config_value("a", array_val).render).to eq("a : [\n    1,\n    2\n]")
     end
   end
 
@@ -570,7 +570,7 @@ describe "ConfigDocument" do
       config_document = ConfigDocumentFactory.parse_string(orig_text)
 
       map = ConfigValueFactory.from_any_ref({"a" => 1, "b" => 2})
-      expect(config_document.set_config_value("a", map).render).to eq("{ a : {\n     # hardcoded value\n     \"a\" : 1,\n     # hardcoded value\n     \"b\" : 2\n } }")
+      expect(config_document.set_config_value("a", map).render).to eq("{ a : {\n     \"a\" : 1,\n     \"b\" : 2\n } }")
     end
   end
 end


### PR DESCRIPTION
Remove unnecessary "# hardcoded value" comments that were being
generated when inserting a hash or an array into a ConfigDocument.