### PR TITLE
(TK-251) Convert symbol keys to strings

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    hocon (0.9.2)
+    hocon (0.9.3)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/hocon/config_value_factory.rb
+++ b/lib/hocon/config_value_factory.rb
@@ -73,7 +73,13 @@ class Hocon::ConfigValueFactory
   # @return a new {@link ConfigObject}
   #
   def self.from_map(values, origin_description = nil)
-    processed_hash = Hash[values.map {|k, v| [k.is_a?(Symbol) ? k.to_s : k, v]}]
-    ConfigImpl.from_any_ref(processed_hash, origin_description)
+    ConfigImpl.from_any_ref(process_hash(values), origin_description)
   end
+
+  private
+
+  def self.process_hash(hash)
+    Hash[hash.map {|k, v| [k.is_a?(Symbol) ? k.to_s : k, v.is_a?(Hash) ? process_hash(v) : v]}]
+  end
+
 end

--- a/lib/hocon/config_value_factory.rb
+++ b/lib/hocon/config_value_factory.rb
@@ -55,7 +55,11 @@ class Hocon::ConfigValueFactory
   # @return a new value
   #
   def self.from_any_ref(object, origin_description = nil)
-    ConfigImpl.from_any_ref(object, origin_description)
+    if object.is_a?(Hash)
+      from_map(object, origin_description)
+    else
+      ConfigImpl.from_any_ref(object, origin_description)
+    end
   end
 
   #
@@ -69,6 +73,7 @@ class Hocon::ConfigValueFactory
   # @return a new {@link ConfigObject}
   #
   def self.from_map(values, origin_description = nil)
-    ConfigImpl.from_any_ref(values, origin_description)
+    processed_hash = Hash[values.map {|k, v| [k.is_a?(Symbol) ? k.to_s : k, v]}]
+    ConfigImpl.from_any_ref(processed_hash, origin_description)
   end
 end

--- a/spec/unit/typesafe/config/config_value_factory_spec.rb
+++ b/spec/unit/typesafe/config/config_value_factory_spec.rb
@@ -58,8 +58,8 @@ describe Hocon::ConfigValueFactory do
     end
 
     it "should convert symbol keys in a map to string keys" do
-      orig_map = {a: 1, b: 2}
-      map = {"a" => 1, "b" => 2}
+      orig_map = {a: 1, b: 2, c: {a: 1, b: 2, c: {a: 1}}}
+      map = {"a" => 1, "b" => 2, "c"=>{"a"=>1, "b"=>2, "c"=>{"a"=>1}}}
       value = Hocon::ConfigValueFactory.from_any_ref(orig_map, nil)
       expect(value).to be_instance_of(Hocon::Impl::SimpleConfigObject)
       expect(value.unwrapped).to eq(map)

--- a/spec/unit/typesafe/config/config_value_factory_spec.rb
+++ b/spec/unit/typesafe/config/config_value_factory_spec.rb
@@ -3,6 +3,7 @@
 require 'spec_helper'
 require 'hocon/config_value_factory'
 require 'hocon/config_render_options'
+require 'hocon/config_error'
 
 describe Hocon::ConfigValueFactory do
   let(:render_options) { Hocon::ConfigRenderOptions.defaults }
@@ -54,6 +55,23 @@ describe Hocon::ConfigValueFactory do
       value = Hocon::ConfigValueFactory.from_any_ref(map, nil)
       expect(value).to be_instance_of(Hocon::Impl::SimpleConfigObject)
       expect(value.unwrapped).to eq(map)
+    end
+
+    it "should convert symbol keys in a map to string keys" do
+      orig_map = {a: 1, b: 2}
+      map = {"a" => 1, "b" => 2}
+      value = Hocon::ConfigValueFactory.from_any_ref(orig_map, nil)
+      expect(value).to be_instance_of(Hocon::Impl::SimpleConfigObject)
+      expect(value.unwrapped).to eq(map)
+
+      value = Hocon::ConfigValueFactory.from_map(orig_map, nil)
+      expect(value).to be_instance_of(Hocon::Impl::SimpleConfigObject)
+      expect(value.unwrapped).to eq(map)
+    end
+
+    it "should not parse maps with non-string and non-symbol keys" do
+      map = {1 => "a", 2 => "b"}
+      expect{ Hocon::ConfigValueFactory.from_any_ref(map, nil) }.to raise_error(Hocon::ConfigError::ConfigBugOrBrokenError)
     end
 
     it "should convert an Enumerable into a SimpleConfigList" do


### PR DESCRIPTION
When parsing a Hash in ConfigValueFactory, automatically convert
all symbol keys to strings.