### PR TITLE
(HC-24) Fix example error

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ conf_map = conf.root.unwrapped
 To use the ConfigDocument API
 
 ```rb
+require 'hocon'
 require 'hocon/parser/config_document_factory'
 require 'hocon/config_value_factory'
 


### PR DESCRIPTION
Fixes issue where the ConfigDocument example would throw an
exception without the proper requires