### PR TITLE
(HC-24) Use simple API in README, fix circular deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,15 +22,18 @@ Basic Usage
 gem install hocon
 ```
 
+To use the simple API, for reading config values:
 
 ```rb
-require 'hocon/config_factory'
+require 'hocon'
 
-conf = Hocon::ConfigFactory.parse_file("myapp.conf")
-conf_map = conf.root.unwrapped
+conf = Hocon.load("myapp.conf")
+puts "Here's a setting: #{conf["foo"]["bar"]["baz"]}"
 ```
 
-To use the ConfigDocument API
+To use the ConfigDocument API, if you need both read/write capability for
+modifying settings in a config file, or if you want to retain access to
+things like comments and line numbers:
 
 ```rb
 require 'hocon/parser/config_document_factory'

--- a/lib/hocon.rb
+++ b/lib/hocon.rb
@@ -1,14 +1,20 @@
 # encoding: utf-8
 
 module Hocon
-  require 'hocon/config_factory'
-
   def self.load(file)
+    # doing this require lazily, because otherwise, classes that need to
+    # `require 'hocon'` to get the module into scope will end up recursing
+    # through this require and probably ending up with circular dependencies.
+    require 'hocon/config_factory'
     config = Hocon::ConfigFactory.parse_file(file)
     return config.root.unwrapped
   end
 
   def self.parse(string)
+    # doing this require lazily, because otherwise, classes that need to
+    # `require 'hocon'` to get the module into scope will end up recursing
+    # through this require and probably ending up with circular dependencies.
+    require 'hocon/config_factory'
     config = Hocon::ConfigFactory.parse_string(string)
     return config.root.unwrapped
   end

--- a/lib/hocon/impl/config_reference.rb
+++ b/lib/hocon/impl/config_reference.rb
@@ -3,12 +3,15 @@
 require 'hocon'
 require 'hocon/impl'
 require 'hocon/impl/abstract_config_value'
-require 'hocon/impl/resolve_source'
-require 'hocon/impl/resolve_result'
 
 class Hocon::Impl::ConfigReference
   include Hocon::Impl::Unmergeable
   include Hocon::Impl::AbstractConfigValue
+
+  # Require these lazily, to avoid circular dependencies
+  require 'hocon/impl/resolve_source'
+  require 'hocon/impl/resolve_result'
+
 
   NotPossibleToResolve = Hocon::Impl::AbstractConfigValue::NotPossibleToResolve
   UnresolvedSubstitutionError = Hocon::ConfigError::UnresolvedSubstitutionError


### PR DESCRIPTION
This commit updates the README to show the simpler version of the
API for basic read operations.

It also fixes some circular dependencies that were causing the
example code for the ConfigDocumentFactory not to work properly.