### PR TITLE
Fix typo when referencing GENERIC OriginType

### DIFF
--- a/lib/hocon/impl/simple_config_origin.rb
+++ b/lib/hocon/impl/simple_config_origin.rb
@@ -212,7 +212,7 @@ class Hocon::Impl::SimpleConfigOrigin
         if a.origin_type == b.origin_type
           a.origin_type
         else
-          Hocon::Impl::OriginType.GENERIC
+          Hocon::Impl::OriginType::GENERIC
         end
 
     # first use the "description" field which has no line numbers


### PR DESCRIPTION
This causes an error when calling resolve on a parsed config `Hocon::ConfigFactory.parse_file(config_file).resolve`