### PR TITLE
(MAINT) bump and relabel version 0.9.4 to 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-## 0.9.4
+## 1.0.0
 
 This is a bugfix release.
+The API is stable enough and the code is being used in production, so the version is also being bumped to 1.0.0
 
 * Fixed a bug wherein calling "Hocon.load" would not
   resolve substitutions.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    hocon (0.9.4)
+    hocon (1.0.0)
 
 GEM
   remote: https://rubygems.org/
@@ -24,6 +24,3 @@ DEPENDENCIES
   bundler (~> 1.5)
   hocon!
   rspec (~> 2.14)
-
-BUNDLED WITH
-   1.10.6

--- a/README.md
+++ b/README.md
@@ -8,13 +8,15 @@ This is a port of the [Typesafe Config](https://github.com/typesafehub/config) l
 The library provides Ruby support for the [HOCON](https://github.com/typesafehub/config/blob/master/HOCON.md) configuration file format.
 
 
-At present, it supports supports parsing and modification of existing HOCON/JSON files via the `ConfigFactory` class and the `ConfigValueFactory` class,and rendering parsed config objects back to a String.
+At present, it supports supports parsing and modification of existing HOCON/JSON files via the `ConfigFactory`
+class and the `ConfigValueFactory` class,and rendering parsed config objects back to a String.
 It also supports the parsing and modification of HOCON/JSON files via `ConfigDocumentFactory`.
 
-**Note:** While the project is production ready, since not all features in the Typesafe library are supported, you may still run into some issues.
-If you find a problem, feel free to open a github issue.
+**Note:** While the project is production ready, since not all features in the Typesafe library are supported,
+you may still run into some issues. If you find a problem, feel free to open a github issue.
 
-The implementation is intended to be as close to a line-for-line port as the two languages allow, in hopes of making it fairly easy to port over new changesets from the Java code base over time.
+The implementation is intended to be as close to a line-for-line port as the two languages allow,
+in hopes of making it fairly easy to port over new changesets from the Java code base over time.
 
 Basic Usage
 ===========
@@ -65,7 +67,8 @@ bundle exec rspec spec
 Unsupported Features
 ====================
 
-This supports many of the same things as the Java library, but there are some notable exceptions. Unsupported features include:
+This supports many of the same things as the Java library, but there are some notable exceptions.
+Unsupported features include:
 
 * Non file includes
 * Loading resources from the class path or URLs

--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@ The library provides Ruby support for the [HOCON](https://github.com/typesafehub
 
 
 At present, it supports supports parsing and modification of existing HOCON/JSON files via the `ConfigFactory`
-class and the `ConfigValueFactory` class,and rendering parsed config objects back to a String.
-It also supports the parsing and modification of HOCON/JSON files via `ConfigDocumentFactory`.
+class and the `ConfigValueFactory` class, and rendering parsed config objects back to a String
+([see examples below](#basic-usage)). It also supports the parsing and modification of HOCON/JSON files via
+`ConfigDocumentFactory`.
 
 **Note:** While the project is production ready, since not all features in the Typesafe library are supported,
 you may still run into some issues. If you find a problem, feel free to open a github issue.

--- a/README.md
+++ b/README.md
@@ -8,10 +8,11 @@ This is a port of the [Typesafe Config](https://github.com/typesafehub/config) l
 The library provides Ruby support for the [HOCON](https://github.com/typesafehub/config/blob/master/HOCON.md) configuration file format.
 
 
-At present, it supports supports parsing and modification of existing HOCON/JSON files via the `ConfigFactory` class and the `ConfigValueFactory` class, and rendering parsed config objects back to a String.
+At present, it supports supports parsing and modification of existing HOCON/JSON files via the `ConfigFactory` class and the `ConfigValueFactory` class,and rendering parsed config objects back to a String.
 It also supports the parsing and modification of HOCON/JSON files via `ConfigDocumentFactory`.
-PLEASE NOTE this project is in an experimental state, and in some cases may not work properly, so
-please be wary when using it. If you find a problem, feel free to open a github issue.
+
+**Note:** While the project is production ready, since not all features in the Typesafe library are supported, you may still run into some issues.
+If you find a problem, feel free to open a github issue.
 
 The implementation is intended to be as close to a line-for-line port as the two languages allow, in hopes of making it fairly easy to port over new changesets from the Java code base over time.
 

--- a/hocon.gemspec
+++ b/hocon.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.name        = 'hocon'
-  s.version     = '0.9.4'
-  s.date        = '2016-02-11'
+  s.version     = '1.0.0'
+  s.date        = '2016-02-16'
   s.summary     = "HOCON Config Library"
   s.description = "== A port of the Java {Typesafe Config}[https://github.com/typesafehub/config] library to Ruby"
   s.authors     = ["Chris Price", "Wayne Warren", "Preben Ingvaldsen", "Joe Pinsonault", "Kevin Corcoran"]


### PR DESCRIPTION
0.9.4 introduced changes that require some users to modify their require
statements due to bugfixes. In addition the API is stable enough to consider this a 1.0.0
release

1.0.0 Changlog:
This is a bugfix release.
The API is stable enough and the code is being used in production, so the version is also being bumped to 1.0.0

* Fixed a bug wherein calling "Hocon.load" would not
  resolve substitutions.
* Fixed a circular dependency between the Hocon and Hocon::ConfigFactory
  namespaces. Using the Hocon::ConfigFactory class now requires you to
  use a `require 'hocon/config_factory'` instead of `require hocon`
* Add support for hashes with keyword keys

**Easier to look at just the first commit** without the whitespace changes in the readme