### PR TITLE
(HC-80) Don't shadow ruby Class/Module#name method

### DIFF
--- a/lib/hocon/config_value_type.rb
+++ b/lib/hocon/config_value_type.rb
@@ -15,7 +15,7 @@ module Hocon::ConfigValueType
   NULL = 4
   STRING = 5
 
-  def self.name(config_value_type)
+  def self.value_type_name(config_value_type)
     case config_value_type
       when OBJECT then "OBJECT"
       when LIST then "LIST"

--- a/lib/hocon/impl/from_map_mode.rb
+++ b/lib/hocon/impl/from_map_mode.rb
@@ -8,7 +8,7 @@ module Hocon::Impl::FromMapMode
   KEYS_ARE_KEYS = 1
   ConfigBugOrBrokenError = Hocon::ConfigError::ConfigBugOrBrokenError
 
-  def self.name(from_map_mode)
+  def self.map_mode_name(from_map_mode)
     case from_map_mode
       when KEYS_ARE_PATHS then "KEYS_ARE_PATHS"
       when KEYS_ARE_KEYS then "KEYS_ARE_KEYS"

--- a/lib/hocon/impl/parseable.rb
+++ b/lib/hocon/impl/parseable.rb
@@ -125,7 +125,7 @@ class Hocon::Impl::Parseable
       raise Hocon::ConfigError::ConfigWrongTypeError.with_expected_actual(value.origin,
                                                          "",
                                                          "object at file root",
-                                                         value.value_type.name)
+                                                         value.value_type.value_type_name)
     end
   end
 

--- a/lib/hocon/impl/simple_config.rb
+++ b/lib/hocon/impl/simple_config.rb
@@ -61,12 +61,12 @@ class Hocon::Impl::SimpleConfig
     if v.value_type == ConfigValueType::NULL
       raise ConfigNullError.new(v.origin,
                                 (ConfigNullError.make_message(original_path.render,
-                                                              (not expected.nil?) ? ConfigValueType.name(expected) : nil)),
+                                                              (not expected.nil?) ? ConfigValueType.value_type_name(expected) : nil)),
                                 nil)
     elsif (not expected.nil?) && v.value_type != expected
       raise ConfigWrongTypeError.new(v.origin,
-                                     "#{original_path.render} has type #{ConfigValueType.name(v.value_type)} " +
-                                         "rather than #{ConfigValueType.name(expected)}",
+                                     "#{original_path.render} has type #{ConfigValueType.value_type_name(v.value_type)} " +
+                                         "rather than #{ConfigValueType.value_type_name(expected)}",
                                      nil)
     else
       return v
@@ -121,8 +121,8 @@ class Hocon::Impl::SimpleConfig
     if (not expected.nil?) && (v.value_type != expected && v.value_type != Hocon::ConfigValueType::NULL)
       raise Hocon::ConfigError::ConfigWrongTypeError.with_expected_actual(v.origin,
                                                                           original_path.render,
-                                                                          expected.name,
-                                                                          Hocon::ConfigValueType.name(v.value_type))
+                                                                          expected.value_type_name,
+                                                                          Hocon::ConfigValueType.value_type_name(v.value_type))
     else
       return v
     end
@@ -220,8 +220,8 @@ class Hocon::Impl::SimpleConfig
       end
       if v.value_type != expected
         raise ConfigWrongTypeError.with_expected_actual(origin, path,
-              "list of #{expected.name}",
-              "list of #{v.value_type.name}")
+              "list of #{expected.value_type_name}",
+              "list of #{v.value_type.value_type_name}")
       end
       l << v.unwrapped
     end
@@ -271,8 +271,8 @@ class Hocon::Impl::SimpleConfig
       end
       if v.value_type != expected
         raise ConfigWrongTypeError.with_expected_actual(origin, path,
-                                                        "list of #{expected.name}",
-                                                        "list of #{v.value_type.name}")
+                                                        "list of #{expected.value_type_name}",
+                                                        "list of #{v.value_type.value_type_name}")
       end
       l << v
     end

--- a/lib/hocon/impl/token.rb
+++ b/lib/hocon/impl/token.rb
@@ -30,7 +30,7 @@ class Hocon::Impl::Token
     if !@debug_string.nil?
       @debug_string
     else
-      Hocon::Impl::TokenType.name(@token_type)
+      Hocon::Impl::TokenType.token_type_name(@token_type)
     end
   end
 

--- a/lib/hocon/impl/token_type.rb
+++ b/lib/hocon/impl/token_type.rb
@@ -21,7 +21,7 @@ class Hocon::Impl::TokenType
   PLUS_EQUALS = 15
   IGNORED_WHITESPACE = 16
 
-  def self.name(token_type)
+  def self.token_type_name(token_type)
     case token_type
       when START then "START"
       when EOF then "EOF"

--- a/lib/hocon/impl/tokens.rb
+++ b/lib/hocon/impl/tokens.rb
@@ -35,9 +35,9 @@ class Hocon::Impl::Tokens
 
     def to_s
       if value.resolve_status == ResolveStatus::RESOLVED
-        "'#{value.unwrapped}' (#{Hocon::ConfigValueType.name(value.value_type)})"
+        "'#{value.unwrapped}' (#{Hocon::ConfigValueType.value_type_name(value.value_type)})"
       else
-        "'<unresolved value>' (#{@value.value_type.name})"
+        "'<unresolved value>' (#{@value.value_type.value_type_name})"
       end
 
     end


### PR DESCRIPTION
Prior to this commit, there were a few places in the code where
we'd ported over a class-or-module-level method named `name` from
the upstream library.  This isn't a good idea in Ruby because it
results in shadowing of the built in Ruby methods Class#name and
Module#name.  This was causing problems for some users, e.g. in
cases where reflection is being used to examine classes.

In this commit we rename all such methods to something more specific,
and replace the calls to the old names with calls to the new names.