### PR TITLE
(HC-81) Fix undefined method `value_type_name' error

### DIFF
--- a/lib/hocon/impl/parseable.rb
+++ b/lib/hocon/impl/parseable.rb
@@ -5,6 +5,7 @@ require 'pathname'
 require 'hocon/impl'
 require 'hocon/config_error'
 require 'hocon/config_syntax'
+require 'hocon/config_value_type'
 require 'hocon/impl/config_impl'
 require 'hocon/impl/simple_include_context'
 require 'hocon/impl/simple_config_object'
@@ -125,7 +126,7 @@ class Hocon::Impl::Parseable
       raise Hocon::ConfigError::ConfigWrongTypeError.with_expected_actual(value.origin,
                                                          "",
                                                          "object at file root",
-                                                         value.value_type.value_type_name)
+                                                         Hocon::ConfigValueType.value_type_name(value.value_type))
     end
   end
 

--- a/lib/hocon/impl/simple_config.rb
+++ b/lib/hocon/impl/simple_config.rb
@@ -118,11 +118,11 @@ class Hocon::Impl::SimpleConfig
       v = Hocon::Impl::DefaultTransformer.transform(v, expected)
     end
 
-    if (not expected.nil?) && (v.value_type != expected && v.value_type != Hocon::ConfigValueType::NULL)
+    if (not expected.nil?) && (v.value_type != expected && v.value_type != ConfigValueType::NULL)
       raise Hocon::ConfigError::ConfigWrongTypeError.with_expected_actual(v.origin,
                                                                           original_path.render,
-                                                                          expected.value_type_name,
-                                                                          Hocon::ConfigValueType.value_type_name(v.value_type))
+                                                                          ConfigValueType.value_type_name(expected),         
+                                                                          ConfigValueType.value_type_name(v.value_type))
     else
       return v
     end
@@ -138,7 +138,7 @@ class Hocon::Impl::SimpleConfig
       else
         o = find_key(me,
                      key,
-                     Hocon::ConfigValueType::OBJECT,
+                     ConfigValueType::OBJECT,
                      original_path.sub_path(0, original_path.length - remainder.length))
 
         if o.nil?
@@ -155,7 +155,7 @@ class Hocon::Impl::SimpleConfig
   def is_null?(path_expression)
     path = Path.new_path(path_expression)
     v = self.class.find_or_null(@object, path, nil, path)
-    v.value_type == Hocon::ConfigValueType::NULL
+    v.value_type == ConfigValueType::NULL
   end
 
   def get_value(path)
@@ -178,7 +178,7 @@ class Hocon::Impl::SimpleConfig
     get_config_number(path)
   end
 
-  def get_string(path)                                                                                                                                                                                                                                                                 
+  def get_string(path)                                                                                                                                                                                                                                                
     v = find2(path, ConfigValueType::STRING)
     v.unwrapped
   end
@@ -220,8 +220,8 @@ class Hocon::Impl::SimpleConfig
       end
       if v.value_type != expected
         raise ConfigWrongTypeError.with_expected_actual(origin, path,
-              "list of #{expected.value_type_name}",
-              "list of #{v.value_type.value_type_name}")
+              "list of #{ConfigValueType.value_type_name(expected)}",
+              "list of #{ConfigValueType.value_type_name(v.value_type)}")
       end
       l << v.unwrapped
     end
@@ -271,8 +271,8 @@ class Hocon::Impl::SimpleConfig
       end
       if v.value_type != expected
         raise ConfigWrongTypeError.with_expected_actual(origin, path,
-                                                        "list of #{expected.value_type_name}",
-                                                        "list of #{v.value_type.value_type_name}")
+                                                        "list of #{ConfigValueType.value_type_name(expected)}",
+                                                        "list of #{ConfigValueType.value_type_name(v.value_type)}")
       end
       l << v
     end

--- a/lib/hocon/impl/tokens.rb
+++ b/lib/hocon/impl/tokens.rb
@@ -10,6 +10,7 @@ require 'hocon/impl/config_null'
 require 'hocon/impl/config_boolean'
 require 'hocon/config_error'
 require 'hocon/impl/resolve_status'
+require 'hocon/config_value_type'
 
 # FIXME the way the subclasses of Token are private with static isFoo and accessors is kind of ridiculous.
 class Hocon::Impl::Tokens
@@ -37,7 +38,7 @@ class Hocon::Impl::Tokens
       if value.resolve_status == ResolveStatus::RESOLVED
         "'#{value.unwrapped}' (#{Hocon::ConfigValueType.value_type_name(value.value_type)})"
       else
-        "'<unresolved value>' (#{@value.value_type.value_type_name})"
+        "'<unresolved value>' ((#{Hocon::ConfigValueType.value_type_name(value.value_type)})"
       end
 
     end

--- a/spec/unit/hocon/hocon_spec.rb
+++ b/spec/unit/hocon/hocon_spec.rb
@@ -7,6 +7,7 @@ require 'hocon/config_error'
 require 'hocon/config_syntax'
 
 ConfigParseError = Hocon::ConfigError::ConfigParseError
+ConfigWrongTypeError = Hocon::ConfigError::ConfigWrongTypeError
 
 describe Hocon do
   let(:render_options) { Hocon::ConfigRenderOptions.defaults }
@@ -44,7 +45,17 @@ describe Hocon do
       let(:conf) { Hocon.parse(string) }
       include_examples "hocon_parsing"
     end
+  end
 
+  it "should fail to parse an array" do
+    puts 
+    expect{(Hocon.parse('[1,2,3]'))}.
+      to raise_error(ConfigWrongTypeError)
+  end
+
+  it "should fail to parse an array" do
+    expect{(Hocon.parse('["one", "two" "three"]'))}.
+      to raise_error(ConfigWrongTypeError)
   end
 
   context "loading a HOCON file with a substitution" do


### PR DESCRIPTION
This repo currently does not consistently and correctly use calls to `value_type_name`, causing undefined method errors. This PR fixes all calls to correctly call the module/class method rather than an instance method which does not exist. This PR also adds two spec tests to make sure that it is correctly attempting to parse arrays and throwing a ConfigWrongTypeError.