### PR TITLE
(MAINT) Update version and changelog for 1.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.2.0
+This is a feature release.
+
+* Added a cli tool called `hocon` for reading and manipulating hocon files
+
 ## 1.1.3
 This is a bugfix release.
 

--- a/lib/hocon/version.rb
+++ b/lib/hocon/version.rb
@@ -1,5 +1,5 @@
 module Hocon
   module Version
-    STRING = '1.2.0'
+    STRING = '1.2.0-SNAPSHOT'
   end
 end


### PR DESCRIPTION
The release job needs to take in the new version number, and that version has to be greater than the version currently in the project. Ruby interprets `1.2.0-SNAPSHOT` as lower than `1.2.0`, so this should work