### PR TITLE
(PE-18165) encode file URIs to handle utf8 chars

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
 source "https://rubygems.org"
 
+gem 'addressable', '2.4.0'
+
 gemspec

--- a/lib/hocon/impl/simple_config_origin.rb
+++ b/lib/hocon/impl/simple_config_origin.rb
@@ -5,6 +5,7 @@ require 'hocon/impl'
 require 'hocon/impl/url'
 require 'hocon/impl/origin_type'
 require 'hocon/config_error'
+require 'addressable'
 
 class Hocon::Impl::SimpleConfigOrigin
 
@@ -39,7 +40,7 @@ class Hocon::Impl::SimpleConfigOrigin
   end
 
   def self.new_file(file_path)
-    url = URI.join('file:///', file_path)
+    url = Addressable::URI.join('file:///', file_path)
     self.new(file_path, -1, -1,
              OriginType::FILE,
              url, nil, nil)

--- a/spec/unit/typesafe/config/conf_parser_spec.rb
+++ b/spec/unit/typesafe/config/conf_parser_spec.rb
@@ -705,6 +705,11 @@ describe "Config Parser" do
     assert_comments_at_path([], conf8, "a")
   end
 
+  context "loading unicode file paths" do
+    it "should be able to parse files with unicode file paths" do
+      expect(Hocon.load("#{FIXTURE_DIR}/test_utils/resources/ᚠᛇᚻ.conf")).to eq({'ᚠᛇᚻ' => '᛫ᛒᛦᚦ᛫ᚠᚱᚩᚠᚢ'})
+    end
+  end
 
   it "includeFile" do
     conf = Hocon::ConfigFactory.parse_string("include file(" +
@@ -780,12 +785,6 @@ describe "Config Parser" do
   # Skipping 'includeResources' because we don't support classpath resources
   # Skipping 'includeURLHeuristically' because we don't support URLs
   # Skipping 'includeURLBasenameHeuristically' because we don't support URLs
-
-  it "shouldacceptUTF8FileNames" do
-    skip('UTF-8 filenames not currently supported') do
-      expect { Hocon::ConfigFactory.parse_file(TestUtils.resource_file("ᚠᛇᚻ.conf")) }.to raise_error
-    end
-  end
 
   it "acceptsUTF8FileContents" do
     # utf8.conf is UTF-8 with no BOM


### PR DESCRIPTION
Prior to this change, the hocon parser would
error when give file names like ᚠᛇᚻ.conf or
/tmp/旗本/pe.conf.

This commit URI encodes the filenames to
avoid that issue.