### PR TITLE
(HC-104) Support environment variable lists

### DIFF
--- a/spec/fixtures/hocon/with_substitution/subst.conf
+++ b/spec/fixtures/hocon/with_substitution/subst.conf
@@ -1,2 +1,3 @@
 a: true
 b: ${a}
+c: ${ENVARRAY}

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -41,3 +41,8 @@ EXAMPLE4 = { :hash =>
              :name => "example4",
 }
 
+# set values out of order to verify they return in-order
+# must be set prior to config_impl.rb loading
+ENV['ENVARRAY.1'] = 'bar'
+ENV['ENVARRAY.2'] = 'baz'
+ENV['ENVARRAY.0'] = 'foo'

--- a/spec/unit/hocon/hocon_spec.rb
+++ b/spec/unit/hocon/hocon_spec.rb
@@ -101,11 +101,11 @@ describe Hocon do
   context "loading config that includes substitutions" do
     it "should be able to `load` from a file" do
       expect(Hocon.load("#{FIXTURE_DIR}/hocon/with_substitution/subst.conf")).
-          to eq({"a" => true, "b" => true})
+          to eq({"a" => true, "b" => true, "c" => ["foo", "bar", "baz"]})
     end
     it "should be able to `parse` from a string" do
       expect(Hocon.parse(File.read("#{FIXTURE_DIR}/hocon/with_substitution/subst.conf"))).
-          to eq({"a" => true, "b" => true})
+          to eq({"a" => true, "b" => true, "c" => ["foo", "bar", "baz"]})
     end
   end
 


### PR DESCRIPTION
 - https://github.com/lightbend/config/pull/427 added support to the
   Java version of Hocon for lists of environment variables.

   For instance, given a Hocon configuration file like:

   "a": ${testList}

   And the environment variables:

   testList.0=0
   testList.1=1

   Then the Hocon configuration file will resolve to the values:

   "a": ["0", "1"]

 - Implement the behavior in the Ruby code and add specs demonstrating
   this new behavior


This is needed to support https://github.com/puppetlabs/pe-bolt-vanagon/pull/35