### PR TITLE
(maint) replace File.exists? with File.exist for ruby3.2

### DIFF
--- a/lib/hocon/impl/parseable.rb
+++ b/lib/hocon/impl/parseable.rb
@@ -442,7 +442,7 @@ class Hocon::Impl::Parseable
       end
       if sibling.nil?
         nil
-      elsif File.exists?(sibling)
+      elsif File.exist?(sibling)
         self.class.trace("#{sibling} exists, so loading it as a file")
         Hocon::Impl::Parseable.new_file(sibling, options.set_origin_description(nil))
       else


### PR DESCRIPTION
File.exists? is already deprecated since ruby 2.1 and will be removed with ruby 3.2. Replace this with File.exist? .

Fixes #126 .