### PR TITLE
(PA-5796) Update Checkout GitHub Action

### DIFF
--- a/.github/workflows/mend.yaml
+++ b/.github/workflows/mend.yaml
@@ -11,7 +11,7 @@ jobs:
     name: Mend Monitor
     steps:
       - name: Checkout current PR
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/rspec_tests.yaml
+++ b/.github/workflows/rspec_tests.yaml
@@ -18,7 +18,7 @@ jobs:
         ruby: [ '2.7', '3.2' ]
     steps:
       - name: Checkout current PR
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Install Ruby version ${{ matrix.ruby }}


### PR DESCRIPTION
The Checkout GitHub Action v3 uses Node 16, which hit end-of-life on September 11, 2023.

This commit updates all instances of the Checkout Action from v3 to v4.